### PR TITLE
BinaryExpressionNumberVisitor accept overloads public

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BinaryExpressionNumberVisitor.java
+++ b/src/main/java/walkingkooka/tree/expression/BinaryExpressionNumberVisitor.java
@@ -37,28 +37,25 @@ public class BinaryExpressionNumberVisitor {
                              final Number right) {
         Objects.requireNonNull(left, "left");
 
-        if (Visiting.CONTINUE == this.startVisit(left, right)) {
-            do {
-                if (left instanceof BigDecimal) {
-                    this.accept((BigDecimal) left, right);
-                    break;
-                }
-                if (left instanceof BigInteger) {
-                    this.accept((BigInteger) left, right);
-                    break;
-                }
-                if (left instanceof Double) {
-                    this.accept((Double) left, right);
-                    break;
-                }
-                if (left instanceof Long) {
-                    this.accept((Long) left, right);
-                    break;
-                }
-                this.visit(left, right);
-            } while (false);
-        }
-        this.endVisit(left, right);
+        do {
+            if (left instanceof BigDecimal) {
+                this.accept((BigDecimal) left, right);
+                break;
+            }
+            if (left instanceof BigInteger) {
+                this.accept((BigInteger) left, right);
+                break;
+            }
+            if (left instanceof Double) {
+                this.accept((Double) left, right);
+                break;
+            }
+            if (left instanceof Long) {
+                this.accept((Long) left, right);
+                break;
+            }
+            this.visit(left, right);
+        } while (false);
     }
 
     protected Visiting startVisit(final Number left,
@@ -79,27 +76,30 @@ public class BinaryExpressionNumberVisitor {
 
     // BIG DECIMAL......................................................................................................
 
-    private void accept(final BigDecimal left,
-                        final Number right) {
-        do {
-            if (right instanceof BigDecimal) {
-                this.visit(left, (BigDecimal) right);
-                break;
-            }
-            if (right instanceof BigInteger) {
-                this.visit(left, (BigInteger) right);
-                break;
-            }
-            if (right instanceof Double) {
-                this.visit(left, (Double) right);
-                break;
-            }
-            if (right instanceof Long) {
-                this.visit(left, (Long) right);
-                break;
-            }
-            this.visit(left, right);
-        } while (false);
+    public void accept(final BigDecimal left,
+                       final Number right) {
+        if (Visiting.CONTINUE == this.startVisit(left, right)) {
+            do {
+                if (right instanceof BigDecimal) {
+                    this.visit(left, (BigDecimal) right);
+                    break;
+                }
+                if (right instanceof BigInteger) {
+                    this.visit(left, (BigInteger) right);
+                    break;
+                }
+                if (right instanceof Double) {
+                    this.visit(left, (Double) right);
+                    break;
+                }
+                if (right instanceof Long) {
+                    this.visit(left, (Long) right);
+                    break;
+                }
+                this.visit(left, right);
+            } while (false);
+        }
+        this.endVisit(left, right);
     }
 
     protected void visit(final BigDecimal left, final BigDecimal right) {
@@ -124,27 +124,30 @@ public class BinaryExpressionNumberVisitor {
 
     // BIG INTEGER......................................................................................................
 
-    private void accept(final BigInteger left,
-                        final Number right) {
-        do {
-            if (right instanceof BigDecimal) {
-                this.visit(left, (BigDecimal) right);
-                break;
-            }
-            if (right instanceof BigInteger) {
-                this.visit(left, (BigInteger) right);
-                break;
-            }
-            if (right instanceof Double) {
-                this.visit(left, (Double) right);
-                break;
-            }
-            if (right instanceof Long) {
-                this.visit(left, (Long) right);
-                break;
-            }
-            this.visit(left, right);
-        } while (false);
+    public void accept(final BigInteger left,
+                       final Number right) {
+        if (Visiting.CONTINUE == this.startVisit(left, right)) {
+            do {
+                if (right instanceof BigDecimal) {
+                    this.visit(left, (BigDecimal) right);
+                    break;
+                }
+                if (right instanceof BigInteger) {
+                    this.visit(left, (BigInteger) right);
+                    break;
+                }
+                if (right instanceof Double) {
+                    this.visit(left, (Double) right);
+                    break;
+                }
+                if (right instanceof Long) {
+                    this.visit(left, (Long) right);
+                    break;
+                }
+                this.visit(left, right);
+            } while (false);
+        }
+        this.endVisit(left, right);
     }
 
     protected void visit(final BigInteger left, final BigDecimal right) {
@@ -169,27 +172,30 @@ public class BinaryExpressionNumberVisitor {
 
     // DOUBLE...........................................................................................................
 
-    private void accept(final Double left,
-                        final Number right) {
-        do {
-            if (right instanceof BigDecimal) {
-                this.visit(left, (BigDecimal) right);
-                break;
-            }
-            if (right instanceof BigInteger) {
-                this.visit(left, (BigInteger) right);
-                break;
-            }
-            if (right instanceof Double) {
-                this.visit(left, (Double) right);
-                break;
-            }
-            if (right instanceof Long) {
-                this.visit(left, (Long) right);
-                break;
-            }
-            this.visit(left, right);
-        } while (false);
+    public void accept(final Double left,
+                       final Number right) {
+        if (Visiting.CONTINUE == this.startVisit(left, right)) {
+            do {
+                if (right instanceof BigDecimal) {
+                    this.visit(left, (BigDecimal) right);
+                    break;
+                }
+                if (right instanceof BigInteger) {
+                    this.visit(left, (BigInteger) right);
+                    break;
+                }
+                if (right instanceof Double) {
+                    this.visit(left, (Double) right);
+                    break;
+                }
+                if (right instanceof Long) {
+                    this.visit(left, (Long) right);
+                    break;
+                }
+                this.visit(left, right);
+            } while (false);
+        }
+        this.endVisit(left, right);
     }
 
     protected void visit(final Double left, final BigDecimal right) {
@@ -213,27 +219,30 @@ public class BinaryExpressionNumberVisitor {
     }
     // LONG.............................................................................................................
 
-    private void accept(final Long left,
-                        final Number right) {
-        do {
-            if (right instanceof BigDecimal) {
-                this.visit(left, (BigDecimal) right);
-                break;
-            }
-            if (right instanceof BigInteger) {
-                this.visit(left, (BigInteger) right);
-                break;
-            }
-            if (right instanceof Double) {
-                this.visit(left, (Double) right);
-                break;
-            }
-            if (right instanceof Long) {
-                this.visit(left, (Long) right);
-                break;
-            }
-            this.visit(left, right);
-        } while (false);
+    public void accept(final Long left,
+                       final Number right) {
+        if (Visiting.CONTINUE == this.startVisit(left, right)) {
+            do {
+                if (right instanceof BigDecimal) {
+                    this.visit(left, (BigDecimal) right);
+                    break;
+                }
+                if (right instanceof BigInteger) {
+                    this.visit(left, (BigInteger) right);
+                    break;
+                }
+                if (right instanceof Double) {
+                    this.visit(left, (Double) right);
+                    break;
+                }
+                if (right instanceof Long) {
+                    this.visit(left, (Long) right);
+                    break;
+                }
+                this.visit(left, right);
+            } while (false);
+        }
+        this.endVisit(left, right);
     }
 
     protected void visit(final Long left, final BigDecimal right) {

--- a/src/test/java/walkingkooka/tree/expression/BinaryExpressionNumberVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BinaryExpressionNumberVisitorTest.java
@@ -91,6 +91,25 @@ public final class BinaryExpressionNumberVisitorTest implements BinaryExpression
                                 @Override
                                 protected void visit(final BigDecimal left,
                                                      final Number right) {
+                                    this.accept((Number) left, BigDecimal.valueOf(right.intValue()));
+                                }
+                            },
+                BigDecimal.valueOf(1),
+                2,
+                "startVisit BigDecimal 1 Integer 2", "startVisit BigDecimal 1 BigDecimal 2", "visit BigDecimal 1 BigDecimal 2", "endVisit BigDecimal 1 BigDecimal 2", "endVisit BigDecimal 1 Integer 2");
+    }
+
+    @Test
+    public void testAcceptBigDecimalUnsupportedAcceptBigDecimalBigDecimal() {
+        this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
+                                @Override
+                                protected void visit(final BigDecimal left, final BigDecimal right) {
+                                    this.logVisit(left, right);
+                                }
+
+                                @Override
+                                protected void visit(final BigDecimal left,
+                                                     final Number right) {
                                     this.accept(left, BigDecimal.valueOf(right.intValue()));
                                 }
                             },
@@ -151,6 +170,25 @@ public final class BinaryExpressionNumberVisitorTest implements BinaryExpression
 
     @Test
     public void testAcceptBigIntegerUnsupported() {
+        this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
+                                @Override
+                                protected void visit(final BigInteger left, final BigInteger right) {
+                                    this.logVisit(left, right);
+                                }
+
+                                @Override
+                                protected void visit(final BigInteger left,
+                                                     final Number right) {
+                                    this.accept((Number) left, BigInteger.valueOf(right.intValue()));
+                                }
+                            },
+                BigInteger.valueOf(1),
+                2,
+                "startVisit BigInteger 1 Integer 2", "startVisit BigInteger 1 BigInteger 2", "visit BigInteger 1 BigInteger 2", "endVisit BigInteger 1 BigInteger 2", "endVisit BigInteger 1 Integer 2");
+    }
+
+    @Test
+    public void testAcceptBigIntegerUnsupportedAcceptBigIntegerBigInteger() {
         this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
                                 @Override
                                 protected void visit(final BigInteger left, final BigInteger right) {
@@ -229,6 +267,26 @@ public final class BinaryExpressionNumberVisitorTest implements BinaryExpression
                                 @Override
                                 protected void visit(final Double left,
                                                      final Number right) {
+                                    this.accept((Number) left, BigInteger.valueOf(right.intValue()));
+                                }
+                            },
+                1.5,
+                2,
+                "startVisit Double 1.5 Integer 2", "startVisit Double 1.5 BigInteger 2", "visit Double 1.5 BigInteger 2", "endVisit Double 1.5 BigInteger 2", "endVisit Double 1.5 Integer 2");
+    }
+
+
+    @Test
+    public void testAcceptDoubleUnsupportedDoubleDouble() {
+        this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
+                                @Override
+                                protected void visit(final Double left, final BigInteger right) {
+                                    this.logVisit(left, right);
+                                }
+
+                                @Override
+                                protected void visit(final Double left,
+                                                     final Number right) {
                                     this.accept(left, BigInteger.valueOf(right.intValue()));
                                 }
                             },
@@ -289,6 +347,25 @@ public final class BinaryExpressionNumberVisitorTest implements BinaryExpression
 
     @Test
     public void testAcceptLongUnsupported() {
+        this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
+                                @Override
+                                protected void visit(final Long left, final BigInteger right) {
+                                    this.logVisit(left, right);
+                                }
+
+                                @Override
+                                protected void visit(final Long left,
+                                                     final Number right) {
+                                    this.accept((Number) left, BigInteger.valueOf(right.intValue()));
+                                }
+                            },
+                1L,
+                2,
+                "startVisit Long 1 Integer 2", "startVisit Long 1 BigInteger 2", "visit Long 1 BigInteger 2", "endVisit Long 1 BigInteger 2", "endVisit Long 1 Integer 2");
+    }
+
+    @Test
+    public void testAcceptLongUnsupportedAcceptLongLong() {
         this.acceptAndCheck(new TestFakeBinaryExpressionNumberVisitor() {
                                 @Override
                                 protected void visit(final Long left, final BigInteger right) {


### PR DESCRIPTION
- Minor performance improvement due to compiler selecting more exact accept overloads.
- All accept overloads call the same visit method sequence.