### PR TITLE
ExpressionNumberConverterToNumberExpressionNumber was ExpressionNumbe…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
@@ -96,17 +96,17 @@ public abstract class ExpressionNumber extends Number implements Comparable<Expr
     }
 
     /**
-     * {@see ExpressionNumberConverterNumberExpressionNumberBigDecimal.expressionNumberBigDecimal}
+     * {@see ExpressionNumberConverterToNumberExpressionNumberBigDecimal.expressionNumberBigDecimal}
      */
-    public static Converter bigDecimalExpressionNumberConverter(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumberBigDecimal.expressionNumberBigDecimal(converter);
+    public static Converter toExpressionNumberBigDecimalConverter(final Converter converter) {
+        return ExpressionNumberConverterToNumberExpressionNumber.expressionNumberBigDecimal(converter);
     }
 
     /**
-     * {@see ExpressionNumberConverterNumberExpressionNumber#expressionNumberDouble}
+     * {@see ExpressionNumberConverterToNumberExpressionNumber#expressionNumberDouble}
      */
-    public static Converter doubleExpressionNumberConverter(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumber.expressionNumberDouble(converter);
+    public static Converter toExpressionNumberDouble(final Converter converter) {
+        return ExpressionNumberConverterToNumberExpressionNumber.expressionNumberDouble(converter);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumber.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumber.java
@@ -32,14 +32,14 @@ import java.util.Objects;
  * and then the ExpressionNumber created. To convert {@link Number} to {@link ExpressionNumber} the wrapped
  * converter should probably be {@link Converters#numberNumber()}.
  */
-abstract class ExpressionNumberConverterNumberExpressionNumber<E> implements Converter {
+abstract class ExpressionNumberConverterToNumberExpressionNumber<E> implements Converter {
 
     static Converter expressionNumberBigDecimal(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumberBigDecimal.with(converter);
+        return ExpressionNumberConverterToNumberExpressionNumberBigDecimal.with(converter);
     }
 
     static Converter expressionNumberDouble(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumberDouble.with(converter);
+        return ExpressionNumberConverterToNumberExpressionNumberDouble.with(converter);
     }
 
     static void checkConverter(final Converter converter) {
@@ -49,7 +49,7 @@ abstract class ExpressionNumberConverterNumberExpressionNumber<E> implements Con
     /**
      * Package private to limit subclassing.
      */
-    ExpressionNumberConverterNumberExpressionNumber(final Converter converter) {
+    ExpressionNumberConverterToNumberExpressionNumber(final Converter converter) {
         super();
         this.converter = converter;
     }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimal.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimal.java
@@ -24,14 +24,14 @@ import java.math.BigDecimal;
 /**
  * In addition to converting to a {@link Number} also supports creating a {@link ExpressionNumber#with(BigDecimal)}.
  */
-final class ExpressionNumberConverterNumberExpressionNumberBigDecimal extends ExpressionNumberConverterNumberExpressionNumber<BigDecimal> {
+final class ExpressionNumberConverterToNumberExpressionNumberBigDecimal extends ExpressionNumberConverterToNumberExpressionNumber<BigDecimal> {
 
-    static ExpressionNumberConverterNumberExpressionNumberBigDecimal with(final Converter converter) {
+    static ExpressionNumberConverterToNumberExpressionNumberBigDecimal with(final Converter converter) {
         checkConverter(converter);
-        return new ExpressionNumberConverterNumberExpressionNumberBigDecimal(converter);
+        return new ExpressionNumberConverterToNumberExpressionNumberBigDecimal(converter);
     }
 
-    private ExpressionNumberConverterNumberExpressionNumberBigDecimal(final Converter converter) {
+    private ExpressionNumberConverterToNumberExpressionNumberBigDecimal(final Converter converter) {
         super(converter);
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor.java
@@ -26,16 +26,16 @@ import java.math.BigInteger;
  * Creates a {@link ExpressionNumberBigDecimal from the given {@link Number}}. This assumes only valid Number sub classes are passed.
  * Passing a {@link ExpressionNumber} will fail.
  */
-final class ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor extends NumberVisitor {
+final class ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor extends NumberVisitor {
 
     static ExpressionNumber wrap(final Number number) {
-        final ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor visitor = new ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor();
+        final ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor visitor = new ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor();
         visitor.accept(number);
         return visitor.result;
     }
 
     // @VisibleForTesting
-    ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor() {
+    ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor() {
         super();
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberDouble.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberDouble.java
@@ -22,14 +22,14 @@ import walkingkooka.convert.Converter;
 /**
  * In addition to converting to a {@link Number} also supports creating a {@link ExpressionNumber#with(double)}.
  */
-final class ExpressionNumberConverterNumberExpressionNumberDouble extends ExpressionNumberConverterNumberExpressionNumber<Double> {
+final class ExpressionNumberConverterToNumberExpressionNumberDouble extends ExpressionNumberConverterToNumberExpressionNumber<Double> {
 
-    static ExpressionNumberConverterNumberExpressionNumberDouble with(final Converter converter) {
+    static ExpressionNumberConverterToNumberExpressionNumberDouble with(final Converter converter) {
         checkConverter(converter);
-        return new ExpressionNumberConverterNumberExpressionNumberDouble(converter);
+        return new ExpressionNumberConverterToNumberExpressionNumberDouble(converter);
     }
 
-    private ExpressionNumberConverterNumberExpressionNumberDouble(final Converter converter) {
+    private ExpressionNumberConverterToNumberExpressionNumberDouble(final Converter converter) {
         super(converter);
     }
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitorTest.java
@@ -20,10 +20,10 @@ package walkingkooka.tree.expression;
 import walkingkooka.math.NumberVisitorTesting;
 import walkingkooka.reflect.JavaVisibility;
 
-public final class ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitorTest implements NumberVisitorTesting<ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor> {
+public final class ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitorTest implements NumberVisitorTesting<ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor> {
     @Override
-    public ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor createVisitor() {
-        return new ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor();
+    public ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor createVisitor() {
+        return new ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor();
     }
 
     @Override
@@ -33,11 +33,11 @@ public final class ExpressionNumberConverterNumberExpressionNumberBigDecimalNumb
 
     @Override
     public String typeNamePrefix() {
-        return ExpressionNumberConverterNumberExpressionNumber.class.getSimpleName();
+        return ExpressionNumberConverterToNumberExpressionNumber.class.getSimpleName();
     }
 
     @Override
-    public Class<ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor> type() {
-        return ExpressionNumberConverterNumberExpressionNumberBigDecimalNumberVisitor.class;
+    public Class<ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor> type() {
+        return ExpressionNumberConverterToNumberExpressionNumberBigDecimalNumberVisitor.class;
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberBigDecimalTest.java
@@ -21,19 +21,19 @@ import walkingkooka.convert.Converter;
 
 import java.math.BigDecimal;
 
-public final class ExpressionNumberConverterNumberExpressionNumberBigDecimalTest extends ExpressionNumberConverterNumberExpressionNumberTestCase<ExpressionNumberConverterNumberExpressionNumberBigDecimal, ExpressionNumberBigDecimal> {
+public final class ExpressionNumberConverterToNumberExpressionNumberBigDecimalTest extends ExpressionNumberConverterToNumberExpressionNumberTestCase<ExpressionNumberConverterToNumberExpressionNumberBigDecimal, ExpressionNumberBigDecimal> {
     @Override
     ExpressionNumberBigDecimal expressionNumber(final double value) {
         return ExpressionNumberBigDecimal.withBigDecimal(BigDecimal.valueOf(value));
     }
 
     @Override
-    public ExpressionNumberConverterNumberExpressionNumberBigDecimal createConverter(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumberBigDecimal.with(converter);
+    public ExpressionNumberConverterToNumberExpressionNumberBigDecimal createConverter(final Converter converter) {
+        return ExpressionNumberConverterToNumberExpressionNumberBigDecimal.with(converter);
     }
 
     @Override
-    public Class<ExpressionNumberConverterNumberExpressionNumberBigDecimal> type() {
-        return ExpressionNumberConverterNumberExpressionNumberBigDecimal.class;
+    public Class<ExpressionNumberConverterToNumberExpressionNumberBigDecimal> type() {
+        return ExpressionNumberConverterToNumberExpressionNumberBigDecimal.class;
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberDoubleTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberDoubleTest.java
@@ -19,7 +19,7 @@ package walkingkooka.tree.expression;
 
 import walkingkooka.convert.Converter;
 
-public final class ExpressionNumberConverterNumberExpressionNumberDoubleTest extends ExpressionNumberConverterNumberExpressionNumberTestCase<ExpressionNumberConverterNumberExpressionNumberDouble, ExpressionNumberDouble> {
+public final class ExpressionNumberConverterToNumberExpressionNumberDoubleTest extends ExpressionNumberConverterToNumberExpressionNumberTestCase<ExpressionNumberConverterToNumberExpressionNumberDouble, ExpressionNumberDouble> {
 
     @Override
     ExpressionNumberDouble expressionNumber(final double value) {
@@ -27,12 +27,12 @@ public final class ExpressionNumberConverterNumberExpressionNumberDoubleTest ext
     }
 
     @Override
-    public ExpressionNumberConverterNumberExpressionNumberDouble createConverter(final Converter converter) {
-        return ExpressionNumberConverterNumberExpressionNumberDouble.with(converter);
+    public ExpressionNumberConverterToNumberExpressionNumberDouble createConverter(final Converter converter) {
+        return ExpressionNumberConverterToNumberExpressionNumberDouble.with(converter);
     }
 
     @Override
-    public Class<ExpressionNumberConverterNumberExpressionNumberDouble> type() {
-        return ExpressionNumberConverterNumberExpressionNumberDouble.class;
+    public Class<ExpressionNumberConverterToNumberExpressionNumberDouble> type() {
+        return ExpressionNumberConverterToNumberExpressionNumberDouble.class;
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberConverterToNumberExpressionNumberTestCase.java
@@ -33,9 +33,9 @@ import java.text.DecimalFormat;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class ExpressionNumberConverterNumberExpressionNumberTestCase<C extends ExpressionNumberConverterNumberExpressionNumber, N extends ExpressionNumber> implements ConverterTesting2<C> {
+public abstract class ExpressionNumberConverterToNumberExpressionNumberTestCase<C extends ExpressionNumberConverterToNumberExpressionNumber, N extends ExpressionNumber> implements ConverterTesting2<C> {
 
-    ExpressionNumberConverterNumberExpressionNumberTestCase() {
+    ExpressionNumberConverterToNumberExpressionNumberTestCase() {
         super();
     }
 
@@ -160,7 +160,7 @@ public abstract class ExpressionNumberConverterNumberExpressionNumberTestCase<C 
 
     @Override
     public final String typeNamePrefix() {
-        return ExpressionNumberConverterNumberExpressionNumber.class.getSimpleName();
+        return ExpressionNumberConverterToNumberExpressionNumber.class.getSimpleName();
     }
 
     @Override


### PR DESCRIPTION
…rConverterNumberExpressionNumber naming

- Added "to" to class name
- Added "to" to factory methods on ExpressionNumber
- TODO similar improvements for "from" (ExpressionNumberConverterExpressionNumber)
- No logic changes.