### PR TITLE
Expression.valueOrFail no longer wraps jre Numbers

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/Expression.java
+++ b/src/main/java/walkingkooka/tree/expression/Expression.java
@@ -48,9 +48,8 @@ public abstract class Expression implements Node<Expression, FunctionExpressionN
     public static Expression valueOrFail(final Object value) {
         Objects.requireNonNull(value, "value");
 
-
-        return value instanceof Number ?
-                expressionNumber(ExpressionNumberKind.DEFAULT.create((Number) value)) :
+        return value instanceof ExpressionNumber ?
+                expressionNumber((ExpressionNumber) value) :
                 value instanceof Boolean ?
                         booleanExpression(Cast.to(value)) :
                         value instanceof LocalDate ?

--- a/src/main/java/walkingkooka/tree/select/ExpressionNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/ExpressionNodeSelectorExpressionEvaluationContext.java
@@ -24,6 +24,7 @@ import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
@@ -32,6 +33,7 @@ import walkingkooka.tree.select.parser.NodeSelectorAttributeName;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -104,11 +106,21 @@ final class ExpressionNodeSelectorExpressionEvaluationContext<N extends Node<N, 
                 .entrySet()
                 .stream()
                 .filter(nameAndValue -> nameAndValue.getKey().value().equals(attributeNameString))
-                .map(nameAndValue -> Expression.valueOrFail(nameAndValue.getValue()))
+                .map(this::toExpression)
                 .findFirst();
         return attributeValue.isPresent() ?
                 attributeValue :
                 ABSENT;
+    }
+
+    /**
+     * Auto convert {@link Number} to {@link ExpressionNumber} and wrap in an {@link Expression}.
+     */
+    private Expression toExpression(final Entry<?, ?> nameAndValue) {
+        final Object value = nameAndValue.getValue();
+        return Expression.valueOrFail(ExpressionNumber.is(value) ?
+                this.expressionNumberKind().create((Number) value) :
+                value);
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/ExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionTest.java
@@ -39,17 +39,17 @@ public final class ExpressionTest implements ClassTesting2<Expression> {
 
     @Test
     public void testValueOrFailUnknownValueTypeFails() {
-        assertThrows(IllegalArgumentException.class, () -> Expression.valueOrFail(this));
+        valueOrFailFails(this);
     }
 
     @Test
-    public void testValueOrFailBigInteger() {
-        this.valueOrFailAndCheck(BigInteger.valueOf(123));
+    public void testValueOrFailBigIntegerFails() {
+        valueOrFailFails(BigInteger.ONE);
     }
 
     @Test
-    public void testValueOrFailBigDecimal() {
-        this.valueOrFailAndCheck(BigDecimal.valueOf(123.5));
+    public void testValueOrFailBigDecimalFails() {
+        valueOrFailFails(BigInteger.TEN);
     }
 
     @Test
@@ -64,32 +64,32 @@ public final class ExpressionTest implements ClassTesting2<Expression> {
 
     @Test
     public void testValueOrFailFloat() {
-        this.valueOrFailAndCheck(123.5f);
+        this.valueOrFailFails(123.5f);
     }
 
     @Test
     public void testValueOrFailDouble() {
-        this.valueOrFailAndCheck(123.5);
+        this.valueOrFailFails(123.5);
     }
 
     @Test
     public void testValueOrFailByte() {
-        this.valueOrFailAndCheck((byte) 123);
+        this.valueOrFailFails((byte) 123);
     }
 
     @Test
     public void testValueOrFailShort() {
-        this.valueOrFailAndCheck((short) 123);
+        this.valueOrFailFails((short) 123);
     }
 
     @Test
     public void testValueOrFailInteger() {
-        this.valueOrFailAndCheck(123);
+        this.valueOrFailFails(123);
     }
 
     @Test
     public void testValueOrFailLong() {
-        this.valueOrFailAndCheck(123L);
+        this.valueOrFailFails(123L);
     }
 
     @Test
@@ -116,6 +116,10 @@ public final class ExpressionTest implements ClassTesting2<Expression> {
     @Test
     public void testValueOrFailText() {
         this.valueOrFailAndCheck("abc123", StringExpression.class);
+    }
+
+    private void valueOrFailFails(final Object value) {
+        assertThrows(IllegalArgumentException.class, () -> Expression.valueOrFail(value));
     }
 
     private void valueOrFailAndCheck(final Object value,

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1769,7 +1769,8 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
     }
 
     private TestNode node(final String name, final Number idAttributeValue, final TestNode... nodes) {
-        return TestNode.with(name, nodes).setAttributes(Maps.of(Names.string("id"), idAttributeValue));
+        return TestNode.with(name, nodes)
+                .setAttributes(Maps.of(Names.string("id"), EXPRESSION_NUMBER_KIND.create(idAttributeValue)));
     }
 
     private void parseExpressionAndCheck(final String expression,
@@ -1818,6 +1819,11 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                     public TestNode selected(final TestNode node) {
                         selected.add(node);
                         return node;
+                    }
+
+                    @Override
+                    public ExpressionNumberKind expressionNumberKind() {
+                        return EXPRESSION_NUMBER_KIND;
                     }
 
                     @Override


### PR DESCRIPTION
- ExpressionNodeSelectorExpressionEvaluationContext wraps jre Numbers correctly
- Closes #150 
