### PR TITLE
ExpressionEvaluationContext.evaluate(Expression)

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -124,6 +124,11 @@ final class BasicExpressionEvaluationContext<C extends ConverterContext> impleme
     private final ExpressionNumberKind expressionNumberKind;
 
     @Override
+    public Object evaluate(final Expression expression) {
+        return expression.toValue(this);
+    }
+
+    @Override
     public Object function(final FunctionExpressionName name, final List<Object> parameters) {
         return this.functions.apply(name, parameters);
     }

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -92,6 +92,11 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
+    public Object evaluate(final Expression expression) {
+        return this.context.evaluate(expression);
+    }
+
+    @Override
     public Object function(final FunctionExpressionName functionName, final List<Object> parameters) {
         return this.context.function(functionName, parameters);
     }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -36,6 +36,11 @@ public interface ExpressionEvaluationContext extends Context, ConvertOrFailFunct
         HasMathContext {
 
     /**
+     * Evaluate the given {@link Expression} returning the result/value.
+     */
+    Object evaluate(final Expression expression);
+
+    /**
      * Constant for functions without any parameters.
      */
     List<Object> NO_PARAMETERS = Lists.empty();

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
@@ -32,6 +32,29 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         ContextTesting<C> {
 
     @Test
+    default void testEvaluateNullExpressionFails() {
+        assertThrows(NullPointerException.class, () -> this.createContext().evaluate(null));
+    }
+
+    @Test
+    default void testEvaluateExpressionUnknownFunctionNameFails() {
+        assertThrows(IllegalArgumentException.class, () -> this.createContext().evaluate(Expression.function(FunctionExpressionName.with("unknown-function-123"), Expression.NO_CHILDREN)));
+    }
+
+    default void evaluateAndCheck(final Expression expression,
+                                  final Object value) {
+        this.evaluateAndCheck(this.createContext(), expression, value);
+    }
+
+    default void evaluateAndCheck(final C context,
+                                  final Expression expression,
+                                  final Object value) {
+        assertEquals(value,
+                context.evaluate(expression),
+                () -> "evaluate " + expression + " " + context);
+    }
+
+    @Test
     default void testFunctionNullNameFails() {
         assertThrows(NullPointerException.class, () -> this.createContext().function(null, ExpressionEvaluationContext.NO_PARAMETERS));
     }

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -37,6 +37,12 @@ public class FakeExpressionEvaluationContext extends FakeDecimalNumberContext im
     }
 
     @Override
+    public Object evaluate(final Expression expression) {
+        Objects.requireNonNull(expression, "expression");
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Object function(final FunctionExpressionName name, final List<Object> parameters) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(parameters, "parameters");

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -74,6 +74,11 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
     }
 
     @Override
+    public Object evaluate(final Expression expression) {
+        return this.context.evaluate(expression);
+    }
+
+    @Override
     public Object function(final FunctionExpressionName name,
                            final List<Object> parameters) {
         return this.context.function(name, parameters);

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -93,6 +93,26 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     }
 
     @Test
+    public void testEvaluateTrue() {
+        this.evaluateAndCheck2(true);
+    }
+
+    @Test
+    public void testEvaluateFalse() {
+        this.evaluateAndCheck2(false);
+    }
+
+    private void evaluateAndCheck2(final boolean value) {
+        this.evaluateAndCheck(Expression.booleanExpression(value), value);
+    }
+
+    @Test
+    public void testEvaluateString() {
+        final String value = "abc123";
+        this.evaluateAndCheck(Expression.string(value), value);
+    }
+
+    @Test
     public void testFunction() {
         assertEquals(this.functionValue(), this.createContext().function(this.functionName(), this.parameters()));
     }

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -65,6 +65,12 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
         assertThrows(NullPointerException.class, () -> CycleDetectingExpressionEvaluationContext.with(null));
     }
 
+    @Test
+    public void testEvaluateString() {
+        final String value = "abc123";
+        this.evaluateAndCheck(Expression.string(value), value);
+    }
+
     public void testFunction() {
         final FunctionExpressionName name = FunctionExpressionName.with("sum");
         final List<Object> parameters = Lists.of("param-1", "param-2");
@@ -311,6 +317,11 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
         final DecimalNumberContext decimalNumberContext = this.decimalNumberContext();
 
         return this.createContext(new FakeExpressionEvaluationContext() {
+
+            @Override
+            public Object evaluate(final Expression expression) {
+                return expression.toValue(this);
+            }
 
             @Override
             public Object function(final FunctionExpressionName name,

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.select;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
@@ -43,6 +44,26 @@ import java.util.function.Function;
 public final class BasicNodeSelectorExpressionEvaluationContextTest implements ExpressionEvaluationContextTesting<BasicNodeSelectorExpressionEvaluationContext> {
 
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
+
+    @Test
+    public void testEvaluateTrue() {
+        this.evaluateAndCheck2(true);
+    }
+
+    @Test
+    public void testEvaluateFalse() {
+        this.evaluateAndCheck2(false);
+    }
+
+    private void evaluateAndCheck2(final boolean value) {
+        this.evaluateAndCheck(Expression.booleanExpression(value), value);
+    }
+
+    @Test
+    public void testEvaluateString() {
+        final String value = "abc123";
+        this.evaluateAndCheck(Expression.string(value), value);
+    }
 
     @Override
     public BasicNodeSelectorExpressionEvaluationContext createContext() {


### PR DESCRIPTION
- Required by https://github.com/mP1/walkingkooka-tree/issues/187
- interface ExpressionFunction should include a method that determines if references are resolved to values