### PR TITLE
walkingkooka-convert/pull/52 CanConvert 20201103

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -147,6 +147,12 @@ final class BasicExpressionEvaluationContext<C extends ConverterContext> impleme
     private final Function<ExpressionReference, Optional<Expression>> references;
 
     @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        return this.converter.canConvert(value, type, this.converterContext);
+    }
+
+    @Override
     public <T> Either<T, String> convert(final Object value,
                                          final Class<T> target) {
         return this.converter.convert(value, target, this.converterContext);

--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionNumberConverterContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionNumberConverterContext.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.tree.expression;
 
+import walkingkooka.Either;
+import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 
 import java.math.MathContext;
@@ -26,17 +28,39 @@ import java.util.Objects;
 
 final class BasicExpressionNumberConverterContext implements ExpressionNumberConverterContext {
 
-    static BasicExpressionNumberConverterContext with(final ConverterContext context, final ExpressionNumberKind kind) {
+    static BasicExpressionNumberConverterContext with(final Converter<ExpressionNumberConverterContext> converter,
+                                                      final ConverterContext context,
+                                                      final ExpressionNumberKind kind) {
+        Objects.requireNonNull(converter, "converter");
         Objects.requireNonNull(context, "context");
         Objects.requireNonNull(kind, "kind");
 
-        return new BasicExpressionNumberConverterContext(context, kind);
+        return new BasicExpressionNumberConverterContext(converter,
+                context,
+                kind);
     }
 
-    private BasicExpressionNumberConverterContext(final ConverterContext context, final ExpressionNumberKind kind) {
+    private BasicExpressionNumberConverterContext(final Converter<ExpressionNumberConverterContext> converter,
+                                                  final ConverterContext context,
+                                                  final ExpressionNumberKind kind) {
+        this.converter = converter;
         this.context = context;
         this.kind = kind;
     }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> target) {
+        return this.converter.canConvert(value, target, this);
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> target) {
+        return this.converter.convert(value, target, this);
+    }
+
+    private final Converter<ExpressionNumberConverterContext> converter;
 
     @Override
     public List<String> ampms() {

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -154,9 +154,15 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
+    public boolean canConvert(final Object from,
+                              final Class<?> type) {
+        return this.context.canConvert(from, type);
+    }
+
+    @Override
     public <T> Either<T, String> convert(final Object from,
-                                         final Class<T> toType) {
-        return this.context.convert(from, toType);
+                                         final Class<T> type) {
+        return this.context.convert(from, type);
     }
 
     private final ExpressionEvaluationContext context;

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -18,9 +18,8 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.Context;
-import walkingkooka.Either;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.convert.ConvertOrFailFunction;
+import walkingkooka.convert.CanConvert;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.HasMathContext;
 
@@ -30,7 +29,8 @@ import java.util.Optional;
 /**
  * Context that travels during any expression evaluation.
  */
-public interface ExpressionEvaluationContext extends Context, ConvertOrFailFunction,
+public interface ExpressionEvaluationContext extends Context,
+        CanConvert,
         DecimalNumberContext,
         ExpressionNumberContext,
         HasMathContext {
@@ -61,23 +61,5 @@ public interface ExpressionEvaluationContext extends Context, ConvertOrFailFunct
      */
     default Expression referenceOrFail(final ExpressionReference reference) {
         return this.reference(reference).orElseThrow(() -> new ExpressionEvaluationReferenceException("Unable to find " + reference));
-    }
-
-    /**
-     * Handles converting the given value to the requested {@link Class target type}.
-     */
-    <T> Either<T, String> convert(final Object value, final Class<T> target);
-
-    /**
-     * Converts the given value to the {@link Class target type} or throws a {@link ExpressionEvaluationConversionException}
-     */
-    default <T> T convertOrFail(final Object value,
-                                final Class<T> target) {
-        final Either<T, String> converted = this.convert(value, target);
-        if (converted.isRight()) {
-            throw new ExpressionEvaluationConversionException(converted.rightValue());
-        }
-
-        return converted.leftValue();
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.expression;
 import org.junit.jupiter.api.Test;
 import walkingkooka.ContextTesting;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.convert.CanConvertTesting;
 import walkingkooka.math.DecimalNumberContextTesting2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Mixing testing interface for {@link ExpressionEvaluationContext}
  */
 public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluationContext> extends DecimalNumberContextTesting2<C>,
+        CanConvertTesting<C>,
         ContextTesting<C> {
 
     @Test
@@ -78,20 +80,15 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         assertThrows(NullPointerException.class, () -> this.createContext().reference(null));
     }
 
-    @Test
-    default void testConvertNullValueFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().convert(null, Object.class));
-    }
-
-    @Test
-    default void testConvertNullTargetTypeFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().convert("value", null));
-    }
-
     default void toValueAndCheck(final Expression node, final ExpressionEvaluationContext context, final Object value) {
         assertEquals(value,
                 node.toValue(context),
                 () -> "Expression.toValue failed, node=" + node + " context=" + context);
+    }
+
+    @Override
+    default C createCanConvert() {
+        return this.createContext();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberConverterContexts.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression;
 
+import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.reflect.PublicStaticHelper;
 
@@ -25,9 +26,12 @@ public final class ExpressionNumberConverterContexts implements PublicStaticHelp
     /**
      * {@see BasicExpressionNumberConverterContext}
      */
-    public static ExpressionNumberConverterContext basic(final ConverterContext context,
+    public static ExpressionNumberConverterContext basic(final Converter<ExpressionNumberConverterContext> converter,
+                                                         final ConverterContext context,
                                                          final ExpressionNumberKind kind) {
-        return BasicExpressionNumberConverterContext.with(context, kind);
+        return BasicExpressionNumberConverterContext.with(converter,
+                context,
+                kind);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -61,6 +61,15 @@ public class FakeExpressionEvaluationContext extends FakeDecimalNumberContext im
     }
 
     @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> target) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(target, "target");
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public <T> Either<T, String> convert(final Object value,
                                          final Class<T> target) {
         Objects.requireNonNull(value, "value");

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
@@ -18,12 +18,10 @@
 package walkingkooka.tree.expression.function;
 
 import walkingkooka.Context;
-import walkingkooka.Either;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.convert.ConvertOrFailFunction;
+import walkingkooka.convert.CanConvert;
 import walkingkooka.locale.HasLocale;
 import walkingkooka.math.HasMathContext;
-import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.expression.ExpressionNumberContext;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
@@ -33,7 +31,7 @@ import java.util.List;
  * Context that accompanies a {@link ExpressionFunction}.
  */
 public interface ExpressionFunctionContext extends Context,
-        ConvertOrFailFunction,
+        CanConvert,
         ExpressionNumberContext,
         HasLocale,
         HasMathContext {
@@ -47,23 +45,4 @@ public interface ExpressionFunctionContext extends Context,
      * Locates a function with the given name and then executes it with the provided parameter values.
      */
     Object function(final FunctionExpressionName name, final List<Object> parameters);
-
-    /**
-     * Handles converting the given value to the {@link Class target type}.
-     */
-    <T> Either<T, String> convert(final Object value,
-                                  final Class<T> target);
-
-    /**
-     * Converts the given value to the {@link Class target type} or throws a {@link ExpressionEvaluationException}
-     */
-    default <T> T convertOrFail(final Object value,
-                                final Class<T> target) {
-        final Either<T, String> converted = this.convert(value, target);
-        if (converted.isRight()) {
-            throw new ExpressionEvaluationException(converted.rightValue());
-        }
-
-        return converted.leftValue();
-    }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContextTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.expression.function;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ContextTesting;
+import walkingkooka.convert.CanConvertTesting;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Mixing testing interface for {@link ExpressionFunctionContext}
  */
-public interface ExpressionFunctionContextTesting<C extends ExpressionFunctionContext> extends ContextTesting<C> {
+public interface ExpressionFunctionContextTesting<C extends ExpressionFunctionContext> extends CanConvertTesting<C>,
+        ContextTesting<C> {
 
     @Test
     default void testFunctionNullNameFails() {
@@ -38,18 +40,12 @@ public interface ExpressionFunctionContextTesting<C extends ExpressionFunctionCo
         assertThrows(NullPointerException.class, () -> this.createContext().function(FunctionExpressionName.with("sum"), null));
     }
 
-    @Test
-    default void testConvertNullValueFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().convert(null, Object.class));
-    }
-
-    @Test
-    default void testConvertNullTargetTypeFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().convert("value", null));
-    }
-
     @Override
     default String typeNameSuffix() {
         return ExpressionFunctionContext.class.getSimpleName();
+    }
+
+    default C createCanConvert() {
+        return this.createContext();
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTesting.java
@@ -80,7 +80,9 @@ public interface ExpressionFunctionTesting<F extends ExpressionFunction<V, C>, V
             return Either.left(Cast.to(value.toString()));
         }
 
-        final ExpressionNumberConverterContext context = ExpressionNumberConverterContexts.basic(ConverterContexts.fake(), this.expressionNumberKind());
+        final ExpressionNumberConverterContext context = ExpressionNumberConverterContexts.basic(Converters.fake(),
+                ConverterContexts.fake(),
+                this.expressionNumberKind());
 
         if (value instanceof String && Number.class.isAssignableFrom(target)) {
             final Double doubleValue = Double.parseDouble((String) value);

--- a/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunctionContext.java
@@ -17,9 +17,7 @@
 
 package walkingkooka.tree.expression.function;
 
-import walkingkooka.Either;
 import walkingkooka.convert.FakeConverterContext;
-import walkingkooka.test.Fake;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
@@ -28,7 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-public class FakeExpressionFunctionContext implements ExpressionFunctionContext, Fake {
+public class FakeExpressionFunctionContext extends FakeConverterContext implements ExpressionFunctionContext {
 
     public FakeExpressionFunctionContext() {
         super();
@@ -38,14 +36,6 @@ public class FakeExpressionFunctionContext implements ExpressionFunctionContext,
     public Object function(final FunctionExpressionName name, final List<Object> parameters) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(parameters, "parameters");
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> Either<T, String> convert(final Object value, final Class<T> target) {
-        Objects.requireNonNull(value, "value");
-        Objects.requireNonNull(target, "target");
-
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -132,6 +132,16 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
     private final static Optional<Expression> ABSENT = Optional.of(Expression.string(""));
 
     @Override
+    public boolean canConvert(final Object value, final Class<?> type) {
+        return this.context.canConvert(value, type);
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value, final Class<T> type) {
+        return this.context.convert(value, type);
+    }
+
+    @Override
     public Locale locale() {
         return this.context.locale();
     }
@@ -139,11 +149,6 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
     @Override
     public MathContext mathContext() {
         return this.context.mathContext();
-    }
-
-    @Override
-    public <T> Either<T, String> convert(final Object value, final Class<T> target) {
-        return this.context.convert(value, target);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionFunctionContext.java
@@ -70,6 +70,12 @@ final class BasicNodeSelectorExpressionFunctionContext<N extends Node<N, NAME, A
     }
 
     @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> target) {
+        return this.context.canConvert(value, target);
+    }
+
+    @Override
     public <T> Either<T, String> convert(final Object value,
                                          final Class<T> target) {
         return this.context.convert(value, target);

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -18,7 +18,6 @@
 package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.Either;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
@@ -124,7 +123,7 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
 
     @Test
     public void testConvert() {
-        assertEquals(Either.left(123L), this.createContext().convert(123.0, Long.class));
+        this.convertAndCheck(123.0, Long.class, 123L);
     }
 
     @Override
@@ -179,7 +178,7 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     }
 
     private ConverterContext converterContext() {
-        return ConverterContexts.basic(DateTimeContexts.fake(), this.decimalNumberContext());
+        return ConverterContexts.basic(this.converter(), DateTimeContexts.fake(), this.decimalNumberContext());
     }
 
     private DecimalNumberContext decimalNumberContext() {

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionNumberConverterContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionNumberConverterContextTest.java
@@ -19,9 +19,11 @@ package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
+import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.ConverterContextTesting;
 import walkingkooka.convert.ConverterContexts;
+import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
@@ -35,15 +37,26 @@ public final class BasicExpressionNumberConverterContextTest implements Converte
         ToStringTesting<BasicExpressionNumberConverterContext> {
 
     private final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
+    private final static Converter<ExpressionNumberConverterContext> CONVERTER = Converters.numberNumber();
+
+    @Test
+    public void testWithNullConverterFails() {
+        assertThrows(NullPointerException.class, () -> BasicExpressionNumberConverterContext.with(null, this.converterContext(), KIND));
+    }
 
     @Test
     public void testWithNullConverterContextFails() {
-        assertThrows(NullPointerException.class, () -> BasicExpressionNumberConverterContext.with(null, KIND));
+        assertThrows(NullPointerException.class, () -> BasicExpressionNumberConverterContext.with(CONVERTER, null, KIND));
     }
 
     @Test
     public void testWithNullExpressionNumberKindFails() {
-        assertThrows(NullPointerException.class, () -> BasicExpressionNumberConverterContext.with(this.converterContext(), null));
+        assertThrows(NullPointerException.class, () -> BasicExpressionNumberConverterContext.with(CONVERTER, this.converterContext(), null));
+    }
+
+    @Test
+    public void testConvert() {
+        this.convertAndCheck(123, Float.class, 123f);
     }
 
     @Test
@@ -53,11 +66,13 @@ public final class BasicExpressionNumberConverterContextTest implements Converte
 
     @Override
     public BasicExpressionNumberConverterContext createContext() {
-        return BasicExpressionNumberConverterContext.with(this.converterContext(), KIND);
+        return BasicExpressionNumberConverterContext.with(CONVERTER, this.converterContext(), KIND);
     }
 
     private ConverterContext converterContext() {
-        return ConverterContexts.basic(DateTimeContexts.locale(Locale.forLanguageTag("EN-AU"), 20), this.decimalNumberContext());
+        return ConverterContexts.basic(Converters.fake(),
+                DateTimeContexts.locale(Locale.forLanguageTag("EN-AU"), 20),
+                this.decimalNumberContext());
     }
 
     private DecimalNumberContext decimalNumberContext() {

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -307,7 +307,11 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
             @Override
             public <T> Either<T, String> convert(final Object value, final Class<T> target) {
                 return Converters.parser(BigInteger.class, Parsers.bigInteger(10), (c) -> ParserContexts.basic(c, c))
-                        .convert(value, target, ConverterContexts.basic(DateTimeContexts.fake(), this));
+                        .convert(value,
+                                target,
+                                ConverterContexts.basic(Converters.fake(),
+                                        DateTimeContexts.fake(),
+                                        this));
             }
         });
         assertEquals(Either.left(BigInteger.valueOf(123)), context.convert("123", BigInteger.class));

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberFromExpressionNumberNumberConverterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberFromExpressionNumberNumberConverterTest.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.expression;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
-import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
@@ -133,7 +132,11 @@ public final class ExpressionNumberFromExpressionNumberNumberConverterTest imple
     }
 
     private ExpressionNumberConverterContext createContext(final ExpressionNumberKind kind) {
-        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.fake(), DecimalNumberContexts.american(MathContext.DECIMAL32)), kind);
+        return ExpressionNumberConverterContexts.basic(Converters.fake(),
+                ConverterContexts.basic(Converters.fake(),
+                        DateTimeContexts.fake(),
+                        DecimalNumberContexts.american(MathContext.DECIMAL32)),
+                kind);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberToExpressionNumberConverterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberToExpressionNumberConverterTest.java
@@ -276,7 +276,9 @@ public final class ExpressionNumberToExpressionNumberConverterTest implements Co
         this.convertAndCheck(ExpressionNumber.toConverter(Converters.numberNumber()),
                 from,
                 target,
-                ExpressionNumberConverterContexts.basic(ConverterContexts.fake(), kind),
+                ExpressionNumberConverterContexts.basic(Converters.fake(),
+                        ConverterContexts.fake(),
+                        kind),
                 number);
     }
 
@@ -348,7 +350,11 @@ public final class ExpressionNumberToExpressionNumberConverterTest implements Co
     }
 
     private ExpressionNumberConverterContext createContext(final ExpressionNumberKind kind) {
-        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.fake(), DecimalNumberContexts.american(MathContext.DECIMAL32)), kind);
+        return ExpressionNumberConverterContexts.basic(Converters.fake(),
+                ConverterContexts.basic(Converters.fake(),
+                        DateTimeContexts.fake(),
+                        DecimalNumberContexts.american(MathContext.DECIMAL32)),
+                kind);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionTestCase.java
@@ -240,7 +240,11 @@ public abstract class ExpressionTestCase<N extends Expression> implements ClassT
     }
 
     private ExpressionNumberConverterContext converterContext() {
-        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.locale(Locale.ENGLISH, 20), DecimalNumberContexts.american(MathContext.DECIMAL32)), EXPRESSION_NUMBER_KIND);
+        return ExpressionNumberConverterContexts.basic(Converters.simple(),
+                ConverterContexts.basic(Converters.fake(),
+                        DateTimeContexts.locale(Locale.ENGLISH, 20),
+                        DecimalNumberContexts.american(MathContext.DECIMAL32)),
+                EXPRESSION_NUMBER_KIND);
     }
 
     ExpressionEvaluationContext context() {

--- a/src/test/java/walkingkooka/tree/expression/LocalDateExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/LocalDateExpressionTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.convert.ConversionException;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
 import walkingkooka.visit.Visiting;
@@ -94,7 +95,7 @@ public final class LocalDateExpressionTest extends LeafExpressionTestCase<LocalD
 
     @Test
     public void testToLocalTime() {
-        assertThrows(ExpressionEvaluationException.class, () -> this.createExpression().toLocalTime(context()));
+        assertThrows(ConversionException.class, () -> this.createExpression().toLocalTime(context()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/expression/LocalTimeExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/LocalTimeExpressionTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.convert.ConversionException;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
 import walkingkooka.visit.Visiting;
@@ -85,7 +86,7 @@ public final class LocalTimeExpressionTest extends LeafExpressionTestCase<LocalT
 
     @Test
     public void testToLocalDate() {
-        assertThrows(ExpressionEvaluationException.class, () -> this.createExpression().toLocalDate(context()));
+        assertThrows(ConversionException.class, () -> this.createExpression().toLocalDate(context()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestCase.java
@@ -72,7 +72,9 @@ public abstract class ExpressionFunctionTestCase<F extends ExpressionFunction<T,
                     return Either.left(Cast.to(value.toString()));
                 }
 
-                final ExpressionNumberConverterContext context = ExpressionNumberConverterContexts.basic(ConverterContexts.fake(), this.expressionNumberKind());
+                final ExpressionNumberConverterContext context = ExpressionNumberConverterContexts.basic(Converters.fake(),
+                        ConverterContexts.fake(),
+                        this.expressionNumberKind());
 
                 if (value instanceof String && Number.class.isAssignableFrom(target)) {
                     final Double doubleValue = Double.parseDouble((String) value);

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
@@ -22,6 +22,8 @@ import walkingkooka.Cast;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
+import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.naming.StringName;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.reflect.ClassTesting2;
@@ -36,8 +38,6 @@ import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
-import walkingkooka.tree.expression.function.ExpressionFunction;
-import walkingkooka.tree.expression.function.ExpressionFunctions;
 
 import java.util.List;
 import java.util.Optional;
@@ -190,7 +190,10 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
             }
 
             private ExpressionNumberConverterContext converterContext() {
-                return ExpressionNumberConverterContexts.basic(ConverterContexts.fake(), KIND);
+                return ExpressionNumberConverterContexts.basic(Converters.fake(),
+                        ConverterContexts.basic(Converters.fake(),
+                                DateTimeContexts.fake(),
+                                DecimalNumberContexts.fake()), KIND);
             }
 
             public String toString() {

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
@@ -67,6 +67,11 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements E
     }
 
     @Test
+    public void testConvert() {
+        this.convertAndCheck(123, Float.class, 123f);
+    }
+
+    @Test
     public void testEvaluateTrue() {
         this.evaluateAndCheck2(true);
     }
@@ -123,10 +128,15 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements E
     }
 
     private Converter<ExpressionNumberConverterContext> converter() {
-        return Converters.simple();
+        return Converters.numberNumber();
     }
+
     private ExpressionNumberConverterContext converterContext() {
-        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.fake(), this.decimalNumberContext()), EXPRESSION_NUMBER_KIND);
+        return ExpressionNumberConverterContexts.basic(Converters.fake(),
+                ConverterContexts.basic(Converters.fake(),
+                        DateTimeContexts.fake(),
+                        this.decimalNumberContext()),
+                EXPRESSION_NUMBER_KIND);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionFunctionContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionFunctionContextTest.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.select;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.Either;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.StringName;
@@ -26,7 +27,6 @@ import walkingkooka.tree.TestNode;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.expression.function.ExpressionFunctionContextTesting;
-import walkingkooka.tree.expression.function.ExpressionFunctionContexts;
 import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
 import java.util.List;
@@ -38,7 +38,21 @@ public final class BasicNodeSelectorExpressionFunctionContextTest implements Exp
         ToStringTesting<BasicNodeSelectorExpressionFunctionContext<TestNode, StringName, StringName, Object>> {
 
     private final static TestNode NODE = TestNode.with("testNode");
-    private final static ExpressionFunctionContext CONTEXT = ExpressionFunctionContexts.fake();
+    private final static ExpressionFunctionContext CONTEXT = new FakeExpressionFunctionContext() {
+        @Override
+        public boolean canConvert(final Object value,
+                                  final Class<?> type) {
+            return value instanceof Integer && Float.class == type;
+        }
+
+        @Override
+        public <T> Either<T, String> convert(final Object value,
+                                             final Class<T> target) {
+            return this.canConvert(value, target) ?
+                    Either.left(target.cast(((Number) value).floatValue())) :
+                    this.failConversion(value, target);
+        }
+    };
 
     @Test
     public void testWithNullNodeFails() {
@@ -48,6 +62,11 @@ public final class BasicNodeSelectorExpressionFunctionContextTest implements Exp
     @Test
     public void testWithNullContextFails() {
         assertThrows(NullPointerException.class, () -> BasicNodeSelectorExpressionFunctionContext.with(NODE, null));
+    }
+
+    @Test
+    public void testConvert() {
+        this.convertAndCheck(123, Float.class, 123f);
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorContext2ExpressionNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorContext2ExpressionNodeSelectorTest.java
@@ -130,18 +130,21 @@ public final class NodeSelectorContext2ExpressionNodeSelectorTest extends NodeSe
                                             }
                                         },
                                         this.converter(),
-                                        ExpressionNumberConverterContexts.basic(this.converterContext(), EXPRESSION_NUMBER_KIND)));
+                                        ExpressionNumberConverterContexts.basic(Converters.fake(), this.converterContext(), EXPRESSION_NUMBER_KIND)));
                     }
 
                     private Converter<ExpressionNumberConverterContext> converter() {
-                        return  Converters.collection(Lists.of(
+                        return Converters.collection(Lists.of(
                                 ExpressionNumber.toConverter(Converters.truthyNumberBoolean()),
                                 ExpressionNumber.fromConverter(Converters.numberNumber()),
                                 Converters.<String, Integer>function(v -> v instanceof String, Predicates.is(Integer.class), Integer::parseInt)));
                     }
 
                     private ExpressionNumberConverterContext converterContext() {
-                        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(ConverterContexts.fake(), DecimalNumberContexts.american(MathContext.DECIMAL32)), EXPRESSION_NUMBER_KIND);
+                        return ExpressionNumberConverterContexts.basic(this.converter(),
+                                ConverterContexts.basic(Converters.fake(),
+                                        ConverterContexts.fake(),
+                                        DecimalNumberContexts.american(MathContext.DECIMAL32)), EXPRESSION_NUMBER_KIND);
                     }
                 });
         context.position = INDEX;

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -47,7 +47,6 @@ import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberExpression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
-import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
@@ -61,7 +60,6 @@ import java.math.MathContext;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -1873,10 +1871,6 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                         }
                     }
 
-                    private Optional<Expression> references(final ExpressionReference reference) {
-                        return Optional.empty();
-                    }
-
                     private Converter<ExpressionNumberConverterContext> converter() {
                         return new Converter<>() {
                             @Override
@@ -1950,8 +1944,13 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                         return Either.right("Failed to convert " + CharSequences.quoteIfChars(value) + " to " + target.getSimpleName());
                     }
 
-                    private final ExpressionNumberConverterContext converterContext() {
-                        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.fake(), decimalNumberContext()), EXPRESSION_NUMBER_KIND);
+                    private ExpressionNumberConverterContext converterContext() {
+                        return ExpressionNumberConverterContexts.basic(Converters.fake(),
+                                ConverterContexts.basic(
+                                        Converters.fake(),
+                                        DateTimeContexts.fake(),
+                                        decimalNumberContext()),
+                                EXPRESSION_NUMBER_KIND);
                     }
                 });
 

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
@@ -27,7 +27,6 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.convert.Converter;
-import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
@@ -46,8 +45,6 @@ import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
-import walkingkooka.tree.expression.function.ExpressionFunction;
-import walkingkooka.tree.expression.function.ExpressionFunctionContexts;
 
 import java.math.MathContext;
 import java.util.Arrays;
@@ -467,7 +464,7 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
 
                         @Override
                         public <T> Either<T, String> convert(final Object value,
-                                                         final Class<T> target) {
+                                                             final Class<T> target) {
                             return NodeSelectorTestCase4.this.converter()
                                     .convert(value,
                                             target,
@@ -491,7 +488,11 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
     }
 
     private ExpressionNumberConverterContext converterContext() {
-        return ExpressionNumberConverterContexts.basic(ConverterContexts.basic(DateTimeContexts.fake(), DecimalNumberContexts.american(MathContext.DECIMAL32)),
+        return ExpressionNumberConverterContexts.basic(
+                this.converter(),
+                ConverterContexts.basic(Converters.fake(),
+                        DateTimeContexts.fake(),
+                        DecimalNumberContexts.american(MathContext.DECIMAL32)),
                 EXPRESSION_NUMBER_KIND);
     }
 


### PR DESCRIPTION
- ExpressionEvaluationContext remove convert declaration implement CanConvert
- ExpressionFunctionContext remove convert declaration implement CanConvert
- BasicExpressionNumberConverterContext added Converter parameter

- https://github.com/mP1/walkingkooka-convert/pull/51
- CanConvert
- CanConvert.convert(Object,Class)
- CanConvertTesting
- ConverterContext implements CanConvert
- BasicConverterContext adds Converter parameter
- Closes #50

- https://github.com/mP1/walkingkooka-convert/pull/52
- CanConvert merged ConvertOrFailFunction 