### PR TITLE
ExpressionEvaluationContext.isPure()

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -117,6 +117,11 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     }
 
     @Override
+    public boolean isPure(final FunctionExpressionName name) {
+        return this.functions.apply(name).isPure();
+    }
+
+    @Override
     public Optional<Expression> reference(final ExpressionReference reference) {
         final Optional<Expression> node = this.references.apply(reference);
         if (!node.isPresent()) {

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -64,6 +64,11 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
+    public boolean isPure(final FunctionExpressionName name) {
+        return this.context.isPure(name);
+    }
+
+    @Override
     public int twoToFourDigitYear(final int year) {
         return this.context.twoToFourDigitYear(year);
     }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -35,6 +35,11 @@ public interface ExpressionEvaluationContext extends ExpressionFunctionContext {
     Object evaluate(final Expression expression);
 
     /**
+     * Tests if the identified {@link ExpressionFunction} is pure.
+     */
+    boolean isPure(final FunctionExpressionName name);
+
+    /**
      * If the {@link ExpressionFunction#resolveReferences()} is true, then replace references with values.
      */
     default List<Object> resolveReferencesIfNecessary(final ExpressionFunction<?, ?> function,

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
@@ -69,6 +69,26 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
     }
 
     @Test
+    default void testIsPureNullNameFails() {
+        assertThrows(NullPointerException.class, () -> this.createContext().isPure(null));
+    }
+
+    default void isPureAndCheck(final FunctionExpressionName name,
+                                final boolean expected) {
+        this.isPureAndCheck(this.createContext(), name, expected);
+    }
+
+    default void isPureAndCheck(final ExpressionEvaluationContext context,
+                                final FunctionExpressionName name,
+                                final boolean expected) {
+        assertEquals(
+                expected,
+                context.isPure(name),
+                () -> "isPure " + name
+        );
+    }
+
+    @Test
     default void testReferenceNullReferenceFails() {
         assertThrows(NullPointerException.class, () -> this.createContext().reference(null));
     }

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -17,13 +17,9 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Either;
-import walkingkooka.math.FakeDecimalNumberContext;
 import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
-import java.math.MathContext;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -43,6 +39,11 @@ public class FakeExpressionEvaluationContext extends FakeExpressionFunctionConte
     public Object evaluate(final FunctionExpressionName name, final List<Object> parameters) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(parameters, "parameters");
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPure(final FunctionExpressionName name) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -118,6 +118,11 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
                 .apply(parameters, this);
     }
 
+    @Override
+    public boolean isPure(final FunctionExpressionName name) {
+        return this.context.isPure(name);
+    }
+
     /**
      * The reference should be an attribute name, cast and find the owner attribute.
      */

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -110,6 +110,24 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     }
 
     @Test
+    public void testIsPureTrue() {
+        this.isPureAndCheck2(true);
+    }
+
+    @Test
+    public void testIsPureFalse() {
+        this.isPureAndCheck2(false);
+    }
+
+    private void isPureAndCheck2(final boolean pure) {
+        this.isPureAndCheck(
+                this.createContext(pure),
+                this.functionName(),
+                pure
+        );
+    }
+
+    @Test
     public void testReferences() {
         assertEquals(Optional.of(this.expression()), this.createContext().reference(REFERENCE));
     }
@@ -134,13 +152,23 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
 
     @Override
     public BasicExpressionEvaluationContext createContext() {
-        return BasicExpressionEvaluationContext.with(KIND,
-                this.functions(),
+        return this.createContext(true);
+    }
+
+    private BasicExpressionEvaluationContext createContext(final boolean pure) {
+        return BasicExpressionEvaluationContext.with(
+                KIND,
+                this.functions(pure),
                 this.references(),
-                this.converterContext());
+                this.converterContext()
+        );
     }
 
     private Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions() {
+        return this.functions(true);
+    }
+
+    private Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions(final boolean pure) {
         return (functionName) -> {
             Objects.requireNonNull(functionName, "functionName");
 
@@ -155,6 +183,11 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                     Objects.requireNonNull(parameters, "parameters");
                     Objects.requireNonNull(context, "context");
                     return BasicExpressionEvaluationContextTest.this.functionValue();
+                }
+
+                @Override
+                public boolean isPure() {
+                    return pure;
                 }
             };
         };

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -91,6 +91,29 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
     }
 
     @Test
+    public void testIsPureFalse() {
+        this.isPureAndCheck2(false);
+    }
+
+    @Test
+    public void testIsPureTrue() {
+        this.isPureAndCheck2(true);
+    }
+
+    private void isPureAndCheck2(final boolean pure) {
+        final FunctionExpressionName functionName = this.functionName();
+        this.isPureAndCheck(
+                this.createContext(pure),
+                functionName,
+                pure
+        );
+    }
+
+    private final FunctionExpressionName functionName() {
+        return FunctionExpressionName.with("function123");
+    }
+
+    @Test
     public void testReference() {
         final Expression target = this.text();
 
@@ -318,6 +341,10 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
 
     @Override
     public CycleDetectingExpressionEvaluationContext createContext() {
+        return this.createContext(true);
+    }
+
+    public CycleDetectingExpressionEvaluationContext createContext(final boolean pure) {
         return this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
@@ -338,6 +365,12 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 Objects.requireNonNull(parameters, "parameters");
 
                 throw new UnknownExpressionFunctionException(name);
+            }
+
+            @Override
+            public boolean isPure(final FunctionExpressionName name) {
+                Objects.requireNonNull(name, "name");
+                return pure;
             }
         });
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/246
- ExpressionEvaluationContext.isPure(Expression)
- Actually isPure(ExpressionFunctionName)