### PR TITLE
mP1/walkingkooka-text-cursor-parser-ebnf/pull/35 EbnfParserCombinator…

### DIFF
--- a/src/test/java/walkingkooka/tree/select/parser/NodeSelectorEbnfParserCombinatorSyntaxTreeTransformerTest.java
+++ b/src/test/java/walkingkooka/tree/select/parser/NodeSelectorEbnfParserCombinatorSyntaxTreeTransformerTest.java
@@ -19,10 +19,11 @@ package walkingkooka.tree.select.parser;
 
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ebnf.combinator.EbnfParserCombinatorSyntaxTreeTransformerTesting;
 
 public final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformerTest implements ClassTesting2<NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer>,
-        EbnfParserCombinatorSyntaxTreeTransformerTesting<NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer> {
+        EbnfParserCombinatorSyntaxTreeTransformerTesting<NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer, ParserContext> {
 
     @Override
     public Class<NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer> type() {


### PR DESCRIPTION
…SyntaxTreeTransformerTesting added missing ParserContext type parameter

- https://github.com/mP1/walkingkooka-text-cursor-parser-ebnf/pull/35
- EbnfParserCombinatorSyntaxTreeTransformerTesting added missing ParserContext type parameter