### PR TITLE
ExpressionFunction.requiresEvaluatedParameters

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/CustomNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/CustomNameExpressionFunction.java
@@ -98,6 +98,11 @@ final class CustomNameExpressionFunction<T, C extends ExpressionFunctionContext>
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return this.function.requiresEvaluatedParameters();
+    }
+
+    @Override
     public boolean resolveReferences() {
         return this.function.resolveReferences();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunction.java
@@ -90,6 +90,14 @@ public interface ExpressionFunction<T, C extends ExpressionFunctionContext> exte
     Class<T> returnType();
 
     /**
+     * When true indicates that any parameters in {@link walkingkooka.tree.expression.Expression} form be evaluated into
+     * java objects prior to invoking invoking {@link #apply(Object, Object)}. For the vast majority of cases all
+     * functions will return true, but for cases such as Excels isError it may be desired to catch any thrown exceptions
+     * and substitute an error object of some kind.
+     */
+    boolean requiresEvaluatedParameters();
+
+    /**
      * When <code>true</code> parameters that implement {@link walkingkooka.tree.expression.ExpressionReference} are resolved to
      * their actual non {@link walkingkooka.tree.expression.Expression} value.
      * This is only honoured when {@link ExpressionFunctionContext#evaluate(FunctionExpressionName, List)} is used.

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTesting.java
@@ -113,6 +113,21 @@ public interface ExpressionFunctionTesting<F extends ExpressionFunction<V, C>, V
 
     C createContext();
 
+    // requiresEvaluatedParameters......................................................................................
+
+    default void requiresEvaluatedParametersAndCheck(final boolean requiresEvaluatedParameters) {
+        this.requiresEvaluatedParametersAndCheck(this.createBiFunction(), requiresEvaluatedParameters);
+    }
+
+    default void requiresEvaluatedParametersAndCheck(final ExpressionFunction<?, ?> function,
+                                                     final boolean requiresEvaluatedParameters) {
+        this.checkEquals(requiresEvaluatedParameters,
+                function.requiresEvaluatedParameters(),
+                () -> function.name() + " requiresEvaluatedParameters: " + function);
+    }
+
+    // resolveReferences................................................................................................
+
     default void resolveReferencesAndCheck(final boolean resolveReference) {
         this.resolveReferencesAndCheck(this.createBiFunction(), resolveReference);
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
@@ -88,6 +88,11 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionFunct
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return true;
+    }
+
+    @Override
     public boolean resolveReferences() {
         return true;
     }

--- a/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunction.java
@@ -55,6 +55,11 @@ public class FakeExpressionFunction<T, C extends ExpressionFunctionContext> impl
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean resolveReferences() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
@@ -90,6 +90,11 @@ final class NodeExpressionFunction<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return true;
+    }
+
+    @Override
     public boolean resolveReferences() {
         return true;
     }

--- a/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
@@ -86,6 +86,11 @@ final class NodeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return true;
+    }
+
+    @Override
     public boolean resolveReferences() {
         return true;
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunction.java
@@ -75,6 +75,11 @@ final class ParametersMapperExpressionFunction<T, C extends ExpressionFunctionCo
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return this.function.requiresEvaluatedParameters();
+    }
+
+    @Override
     public boolean resolveReferences() {
         return this.function.resolveReferences();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
@@ -83,6 +83,11 @@ final class TypeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     }
 
     @Override
+    public boolean requiresEvaluatedParameters() {
+        return true;
+    }
+
+    @Override
     public boolean resolveReferences() {
         return true;
     }

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestingTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestingTest.java
@@ -25,6 +25,7 @@ import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.FunctionExpressionName;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -176,6 +177,65 @@ public final class ExpressionFunctionTestingTest implements ClassTesting<Express
                         .collect(Collectors.joining());
             }
         };
+    }
+
+    // requiresEvaluatedParameters.....................................................................................
+
+    @Test
+    public void testRequiresEvaluatedParametersTrue() {
+        requiresEvaluatedParametersAndCheck(true);
+    }
+
+    @Test
+    public void testRequiresEvaluatedParametersFalse() {
+        requiresEvaluatedParametersAndCheck(false);
+    }
+
+    private void requiresEvaluatedParametersAndCheck(final boolean requires) {
+        this.requiresEvaluatedParametersAndCheck(requires, requires);
+    }
+
+    @Test
+    public void testRequiresEvaluatedParametersFails() {
+        boolean failed = false;
+        try {
+            requiresEvaluatedParametersAndCheck(false, true);
+        } catch (final AssertionError expected) {
+            failed = true;
+        }
+        this.checkEquals(true, failed);
+    }
+
+    private void requiresEvaluatedParametersAndCheck(final boolean requires,
+                                                     final boolean expected) {
+        new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+            @Override
+            public FakeExpressionFunctionContext createContext() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                throw new UnsupportedOperationException();
+            }
+        }.requiresEvaluatedParametersAndCheck(
+                new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
+
+                    @Override
+                    public FunctionExpressionName name() {
+                        return FunctionExpressionName.with("test-function");
+                    }
+
+                    @Override
+                    public boolean requiresEvaluatedParameters() {
+                        return requires;
+                    }
+                }, expected);
     }
 
     // convert.........................................................................................................

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -2013,6 +2013,11 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                                      final NodeSelectorExpressionEvaluationContext<TestNode, StringName, StringName, Object> context);
 
         @Override
+        public boolean requiresEvaluatedParameters() {
+            return true;
+        }
+
+        @Override
         public boolean resolveReferences() {
             return true;
         }


### PR DESCRIPTION
- ExpressionFunction.toValue() updated to honour requiresEvaluatedParameters

- Closes https://github.com/mP1/walkingkooka-tree/issues/380
- ExpressionFunction.shouldReceiveEvaluatedParameters