### PR TITLE
ExpressionFunctionParameterCardinality

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -63,7 +63,7 @@ public class JunitTest {
     // TODO verify Class.cast is emulated
     @Test
     public void testExpressionFunctionParameterGetOrFail() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameterName.with("test123").setType(Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameterName.with("test123").required(Integer.class);
         Assert.assertEquals(
                 Integer.valueOf(100),
                 parameter.<Integer>getOrFail(

--- a/src/main/java/walkingkooka/tree/expression/function/CustomNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/CustomNameExpressionFunction.java
@@ -88,11 +88,6 @@ final class CustomNameExpressionFunction<T, C extends ExpressionFunctionContext>
     }
 
     @Override
-    public boolean lsLastParameterVariable() {
-        return this.function.lsLastParameterVariable();
-    }
-
-    @Override
     public Class<T> returnType() {
         return this.function.returnType();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
@@ -37,25 +37,25 @@ public final class ExpressionFunctionParameter<T> {
 
     public final static List<ExpressionFunctionParameter<?>> EMPTY = Lists.empty();
 
-    public final static ExpressionFunctionParameter<Boolean> BOOLEAN = ExpressionFunctionParameterName.BOOLEAN.setType(Boolean.class);
+    public final static ExpressionFunctionParameter<Boolean> BOOLEAN = ExpressionFunctionParameterName.BOOLEAN.required(Boolean.class);
 
-    public final static ExpressionFunctionParameter<Character> CHARACTER = ExpressionFunctionParameterName.CHARACTER.setType(Character.class);
+    public final static ExpressionFunctionParameter<Character> CHARACTER = ExpressionFunctionParameterName.CHARACTER.required(Character.class);
 
-    public final static ExpressionFunctionParameter<LocalDate> DATE = ExpressionFunctionParameterName.DATE.setType(LocalDate.class);
+    public final static ExpressionFunctionParameter<LocalDate> DATE = ExpressionFunctionParameterName.DATE.required(LocalDate.class);
 
-    public final static ExpressionFunctionParameter<LocalDateTime> DATETIME = ExpressionFunctionParameterName.DATETIME.setType(LocalDateTime.class);
+    public final static ExpressionFunctionParameter<LocalDateTime> DATETIME = ExpressionFunctionParameterName.DATETIME.required(LocalDateTime.class);
 
-    public final static ExpressionFunctionParameter<ExpressionNumber> NUMBER = ExpressionFunctionParameterName.NUMBER.setType(ExpressionNumber.class);
+    public final static ExpressionFunctionParameter<ExpressionNumber> NUMBER = ExpressionFunctionParameterName.NUMBER.required(ExpressionNumber.class);
 
-    public final static ExpressionFunctionParameter<ExpressionReference> REFERENCE = ExpressionFunctionParameterName.REFERENCE.setType(ExpressionReference.class);
+    public final static ExpressionFunctionParameter<ExpressionReference> REFERENCE = ExpressionFunctionParameterName.REFERENCE.required(ExpressionReference.class);
 
-    public final static ExpressionFunctionParameter<String> STRING = ExpressionFunctionParameterName.STRING.setType(String.class);
+    public final static ExpressionFunctionParameter<String> STRING = ExpressionFunctionParameterName.STRING.required(String.class);
 
-    public final static ExpressionFunctionParameter<String> TEXT = ExpressionFunctionParameterName.TEXT.setType(String.class);
+    public final static ExpressionFunctionParameter<String> TEXT = ExpressionFunctionParameterName.TEXT.required(String.class);
 
-    public final static ExpressionFunctionParameter<LocalTime> TIME = ExpressionFunctionParameterName.TIME.setType(LocalTime.class);
+    public final static ExpressionFunctionParameter<LocalTime> TIME = ExpressionFunctionParameterName.TIME.required(LocalTime.class);
 
-    public final static ExpressionFunctionParameter<Object> VALUE = ExpressionFunctionParameterName.VALUE.setType(Object.class);
+    public final static ExpressionFunctionParameter<Object> VALUE = ExpressionFunctionParameterName.VALUE.required(Object.class);
 
     /**
      * Helper that creates a read only list of the given parameters.
@@ -65,17 +65,21 @@ public final class ExpressionFunctionParameter<T> {
     }
 
     public static <T> ExpressionFunctionParameter<T> with(final ExpressionFunctionParameterName name,
-                                                          final Class<T> type) {
+                                                          final Class<T> type,
+                                                          final ExpressionFunctionParameterCardinality cardinality) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(cardinality, "cardinality");
 
-        return new ExpressionFunctionParameter<>(name, type);
+        return new ExpressionFunctionParameter<>(name, type, cardinality);
     }
 
     private ExpressionFunctionParameter(final ExpressionFunctionParameterName name,
-                                        final Class<T> type) {
+                                        final Class<T> type,
+                                        final ExpressionFunctionParameterCardinality cardinality) {
         this.name = name;
         this.type = type;
+        this.cardinality = cardinality;
     }
 
     public ExpressionFunctionParameterName name() {
@@ -89,6 +93,12 @@ public final class ExpressionFunctionParameter<T> {
     }
 
     private final Class<T> type;
+
+    public ExpressionFunctionParameterCardinality cardinality() {
+        return this.cardinality;
+    }
+
+    private final ExpressionFunctionParameterCardinality cardinality;
 
     /**
      * Gets the parameter at index or uses the default
@@ -150,7 +160,7 @@ public final class ExpressionFunctionParameter<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.name, this.type);
+        return Objects.hash(this.name, this.type, this.cardinality);
     }
 
     public boolean equals(final Object other) {
@@ -158,11 +168,13 @@ public final class ExpressionFunctionParameter<T> {
     }
 
     private boolean equals0(final ExpressionFunctionParameter other) {
-        return this.name.equals(other.name) && this.type.equals(other.type);
+        return this.name.equals(other.name) &&
+                this.type.equals(other.type) &&
+                this.cardinality == other.cardinality;
     }
 
     @Override
     public String toString() {
-        return this.type.getName() + " " + this.name;
+        return this.type.getName() + " " + this.name + this.cardinality.parameterToString;
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCardinality.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCardinality.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression.function;
+
+public enum ExpressionFunctionParameterCardinality {
+
+    REQUIRED("", 1, 1),
+
+    OPTIONAL("?", 0, 1),
+
+    VARIABLE("*", 0, Integer.MAX_VALUE); // only legal for last parameter
+
+    ExpressionFunctionParameterCardinality(final String parameterToString,
+                                           final int min,
+                                           final int max) {
+        this.parameterToString = parameterToString;
+        this.min = min;
+        this.max = max;
+    }
+
+    final int min;
+
+    final int max;
+
+    /**
+     * The last component appended to {@link ExpressionFunctionParameter#toString()}
+     */
+    final String parameterToString;
+}

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterName.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterName.java
@@ -106,10 +106,36 @@ public final class ExpressionFunctionParameterName implements Name,
     private final String name;
 
     /**
-     * Factory that creates a {@link ExpressionFunctionParameter} with this name and the given {@link Class type}.
+     * Factory that creates a REQUIRED {@link ExpressionFunctionParameter} with this name and the given {@link Class type}.
      */
-    public <T> ExpressionFunctionParameter<T> setType(final Class<T> type) {
-        return ExpressionFunctionParameter.with(this, type);
+    public <T> ExpressionFunctionParameter<T> required(final Class<T> type) {
+        return ExpressionFunctionParameter.with(
+                this,
+                type,
+                ExpressionFunctionParameterCardinality.REQUIRED
+        );
+    }
+
+    /**
+     * Factory that creates a OPTIONAL {@link ExpressionFunctionParameter} with this name and the given {@link Class type}.
+     */
+    public <T> ExpressionFunctionParameter<T> optional(final Class<T> type) {
+        return ExpressionFunctionParameter.with(
+                this,
+                type,
+                ExpressionFunctionParameterCardinality.OPTIONAL
+        );
+    }
+
+    /**
+     * Factory that creates a VARIABLE {@link ExpressionFunctionParameter} with this name and the given {@link Class type}.
+     */
+    public <T> ExpressionFunctionParameter<T> variable(final Class<T> type) {
+        return ExpressionFunctionParameter.with(
+                this,
+                type,
+                ExpressionFunctionParameterCardinality.VARIABLE
+        );
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
@@ -56,7 +56,7 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionFunct
     @Override
     public ExpressionNumber apply(final List<Object> parameters,
                                   final C context) {
-        this.checkOnlyRequiredParameters(parameters);
+        this.checkParameterCount(parameters);
 
         return NUMBER.getOrFail(parameters, 0)
                 .map(
@@ -73,11 +73,10 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionFunct
     }
 
     private final static ExpressionFunctionParameter<ExpressionNumber> NUMBER = ExpressionFunctionParameterName.with("number")
-            .setType(ExpressionNumber.class);
+            .required(ExpressionNumber.class);
 
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = ExpressionFunctionParameter.list(NUMBER);
 
-    @Override
     public boolean lsLastParameterVariable() {
         return false;
     }

--- a/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunction.java
@@ -45,11 +45,6 @@ public class FakeExpressionFunction<T, C extends ExpressionFunctionContext> impl
     }
 
     @Override
-    public boolean lsLastParameterVariable() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Class<T> returnType() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
@@ -80,11 +80,6 @@ final class NodeExpressionFunction<N extends Node<N, NAME, ANAME, AVALUE>,
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = Lists.empty();
 
     @Override
-    public boolean lsLastParameterVariable() {
-        return false;
-    }
-
-    @Override
     public Class<N> returnType() {
         return Cast.to(Node.class);
     }

--- a/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
@@ -51,7 +51,7 @@ final class NodeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     @Override
     public String apply(final List<Object> parameters,
                         final C context) {
-        this.checkOnlyRequiredParameters(parameters);
+        this.checkParameterCount(parameters);
 
         return NODE.getOrFail(parameters, 0)
                 .name()
@@ -71,14 +71,9 @@ final class NodeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     }
 
     private final static ExpressionFunctionParameter<Node> NODE = ExpressionFunctionParameterName.with("node")
-            .setType(Node.class);
+            .required(Node.class);
 
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = ExpressionFunctionParameter.list(NODE);
-
-    @Override
-    public boolean lsLastParameterVariable() {
-        return false;
-    }
 
     @Override
     public Class<String> returnType() {

--- a/src/main/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunction.java
@@ -65,11 +65,6 @@ final class ParametersMapperExpressionFunction<T, C extends ExpressionFunctionCo
     }
 
     @Override
-    public boolean lsLastParameterVariable() {
-        return this.function.lsLastParameterVariable();
-    }
-
-    @Override
     public Class<T> returnType() {
         return this.function.returnType();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
@@ -57,7 +57,8 @@ final class TypeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     @Override
     public String apply(final List<Object> parameters,
                         final C context) {
-        this.checkOnlyRequiredParameters(parameters);
+        this.checkParameterCount(parameters);
+
         return PARAMETER.getOrFail(parameters, 0)
                 .getClass()
                 .getName();
@@ -68,14 +69,9 @@ final class TypeNameExpressionFunction<C extends ExpressionFunctionContext> impl
         return PARAMETERS;
     }
 
-    private final static ExpressionFunctionParameter<Object> PARAMETER = ExpressionFunctionParameterName.with("parameter").setType(Object.class);
+    private final static ExpressionFunctionParameter<Object> PARAMETER = ExpressionFunctionParameterName.with("parameter").required(Object.class);
 
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = ExpressionFunctionParameter.list(PARAMETER);
-
-    @Override
-    public boolean lsLastParameterVariable() {
-        return false;
-    }
 
     @Override
     public Class<String> returnType() {

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCardinalityTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCardinalityTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression.function;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class ExpressionFunctionParameterCardinalityTest implements ClassTesting<ExpressionFunctionParameterCardinality> {
+
+    @Override
+    public Class<ExpressionFunctionParameterCardinality> type() {
+        return ExpressionFunctionParameterCardinality.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterNameTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterNameTest.java
@@ -73,13 +73,36 @@ public final class ExpressionFunctionParameterNameTest implements ClassTesting2<
     }
 
     @Test
-    public void testSetType() {
+    public void testRequired() {
         final ExpressionFunctionParameterName name = this.createObject();
 
         final Class<String> type = String.class;
-        final ExpressionFunctionParameter<String> parameter = name.setType(type);
+        final ExpressionFunctionParameter<String> parameter = name.required(type);
         assertSame(name, parameter.name(), "name");
         assertSame(type, parameter.type(), "type");
+        assertSame(ExpressionFunctionParameterCardinality.REQUIRED, parameter.cardinality(), "cardinality");
+    }
+
+    @Test
+    public void testOptional() {
+        final ExpressionFunctionParameterName name = this.createObject();
+
+        final Class<String> type = String.class;
+        final ExpressionFunctionParameter<String> parameter = name.optional(type);
+        assertSame(name, parameter.name(), "name");
+        assertSame(type, parameter.type(), "type");
+        assertSame(ExpressionFunctionParameterCardinality.OPTIONAL, parameter.cardinality(), "cardinality");
+    }
+
+    @Test
+    public void testVariable() {
+        final ExpressionFunctionParameterName name = this.createObject();
+
+        final Class<String> type = String.class;
+        final ExpressionFunctionParameter<String> parameter = name.variable(type);
+        assertSame(name, parameter.name(), "name");
+        assertSame(type, parameter.type(), "type");
+        assertSame(ExpressionFunctionParameterCardinality.VARIABLE, parameter.cardinality(), "cardinality");
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefinedTesting2<ExpressionFunctionParameter<String>>,
@@ -41,21 +42,28 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     private final static Class<String> TYPE = String.class;
 
+    private final static ExpressionFunctionParameterCardinality CARDINALITY = ExpressionFunctionParameterCardinality.REQUIRED;
+
     @Test
     public void testWithNullNameFails() {
-        assertThrows(NullPointerException.class, () -> ExpressionFunctionParameter.with(null, TYPE));
+        assertThrows(NullPointerException.class, () -> ExpressionFunctionParameter.with(null, TYPE, CARDINALITY));
     }
 
     @Test
     public void testWithNullTypeFails() {
-        assertThrows(NullPointerException.class, () -> ExpressionFunctionParameter.with(NAME, null));
+        assertThrows(NullPointerException.class, () -> ExpressionFunctionParameter.with(NAME, null, CARDINALITY));
+    }
+
+    @Test
+    public void testWithNullCardinalityFails() {
+        assertThrows(NullPointerException.class, () -> ExpressionFunctionParameter.with(NAME, TYPE, null));
     }
 
     // get.............................................................................................................
 
     @Test
     public void testGetMissing() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 Optional.empty(),
                 parameter.get(
@@ -70,7 +78,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
     @Test
     @Disabled("Need to emulate Class.cast")
     public void testGetWrongTypeFails() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         assertThrows(
                 ClassCastException.class,
                 () -> {
@@ -86,7 +94,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testGet() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 Optional.of(100),
                 parameter.get(
@@ -103,7 +111,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testGetOrDefaultMissing() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 200,
                 parameter.getOrDefault(
@@ -119,7 +127,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
     @Test
     @Disabled("Need to emulate Class.cast")
     public void testGetOrDefaultWrongTypeFails() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         assertThrows(
                 ClassCastException.class,
                 () -> {
@@ -136,7 +144,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testGetOrDefault() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 100,
                 parameter.getOrDefault(
@@ -154,7 +162,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testGetOrFailMissingFails() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> {
@@ -171,7 +179,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
     @Test
     @Disabled("Need to emulate Class.cast")
     public void testGetOrFailWrongTypeFails() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         assertThrows(
                 ClassCastException.class,
                 () -> {
@@ -187,7 +195,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testGetOrFail() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 100,
                 parameter.getOrFail(
@@ -204,7 +212,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testConvert() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 Either.left(12),
                 parameter.convert(
@@ -216,7 +224,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testConvertOrFail() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(NAME, Integer.class, CARDINALITY);
         this.checkEquals(
                 12,
                 parameter.convertOrFail(
@@ -240,8 +248,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testList() {
-        final ExpressionFunctionParameter<String> string = ExpressionFunctionParameterName.with("string").setType(String.class);
-        final ExpressionFunctionParameter<Integer> integer = ExpressionFunctionParameterName.with("integer").setType(Integer.class);
+        final ExpressionFunctionParameter<String> string = ExpressionFunctionParameterName.with("string").required(String.class);
+        final ExpressionFunctionParameter<Integer> integer = ExpressionFunctionParameterName.with("integer").required(Integer.class);
 
         this.checkEquals(
                 Lists.of(string, integer),
@@ -251,22 +259,78 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     @Test
     public void testDifferentName() {
-        this.checkNotEquals(ExpressionFunctionParameter.with(ExpressionFunctionParameterName.with("different"), TYPE));
+        this.checkNotEquals(
+                ExpressionFunctionParameter.with(
+                        ExpressionFunctionParameterName.with("different"),
+                        TYPE,
+                        CARDINALITY
+                )
+        );
     }
 
     @Test
     public void testDifferentType() {
-        this.checkNotEquals(ExpressionFunctionParameter.with(NAME, Integer.class));
+        this.checkNotEquals(
+                ExpressionFunctionParameter.with(
+                        NAME,
+                        Integer.class,
+                        CARDINALITY
+                )
+        );
     }
 
     @Test
-    public void testToString() {
-        this.toStringAndCheck(this.createObject(), "java.lang.String name");
+    public void testDifferentCardinality() {
+        assertNotSame(ExpressionFunctionParameterCardinality.OPTIONAL, CARDINALITY);
+
+        this.checkNotEquals(
+                ExpressionFunctionParameter.with(
+                        NAME,
+                        Integer.class,
+                        ExpressionFunctionParameterCardinality.OPTIONAL
+                )
+        );
+    }
+
+    @Test
+    public void testToStringRequired() {
+        this.toStringAndCheck(
+                ExpressionFunctionParameter.with(
+                        NAME,
+                        TYPE,
+                        ExpressionFunctionParameterCardinality.REQUIRED
+                ),
+                "java.lang.String name"
+        );
+    }
+
+    @Test
+    public void testToStringOptional() {
+        this.toStringAndCheck(
+                ExpressionFunctionParameter.with(
+                        NAME,
+                        TYPE,
+                        ExpressionFunctionParameterCardinality.OPTIONAL
+                ),
+                "java.lang.String name?"
+        );
+    }
+
+    @Test
+    public void testToStringVariabled() {
+        this.toStringAndCheck(
+                ExpressionFunctionParameter.with(
+                        NAME,
+                        TYPE,
+                        ExpressionFunctionParameterCardinality.VARIABLE
+                ),
+                "java.lang.String name*"
+        );
     }
 
     @Override
     public ExpressionFunctionParameter<String> createObject() {
-        return ExpressionFunctionParameter.with(NAME, TYPE);
+        return ExpressionFunctionParameter.with(NAME, TYPE, CARDINALITY);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTest.java
@@ -22,117 +22,165 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunction> {
 
+    private final static ExpressionFunctionParameter<Integer> REQUIRED = ExpressionFunctionParameterName.with("required")
+            .required(Integer.class);
 
-    // checkOnlyRequiredParameters.....................................................................................
+    private final static ExpressionFunctionParameter<Boolean> OPTIONAL = ExpressionFunctionParameterName.with("optional")
+            .optional(Boolean.class);
+
+    private final static ExpressionFunctionParameter<String> VARIABLE = ExpressionFunctionParameterName.with("variable")
+            .variable(String.class);
+
+    // checkParameterCount..............................................................................................
 
     @Test
-    public void testCheckOnlyRequiredParametersLess() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
-                        @Override
-                        public List<ExpressionFunctionParameter<?>> parameters() {
-                            return ExpressionFunctionParameter.list(
-                                    ExpressionFunctionParameterName.with("first").setType(Integer.class),
-                                    ExpressionFunctionParameterName.with("second").setType(Integer.class)
-                            );
-                        }
-                    }.checkOnlyRequiredParameters(Lists.of(1));
-                }
-        );
+    public void testCheckParametersRequired() {
+        this.checkParameters(1, REQUIRED);
     }
 
     @Test
-    public void testCheckOnlyRequiredParametersSame() {
+    public void testCheckParametersRequiredRequired() {
+        this.checkParameters(2, REQUIRED, REQUIRED);
+    }
+
+    @Test
+    public void testCheckParametersRequiredRequiredRequired() {
+        this.checkParameters(3, REQUIRED, REQUIRED, REQUIRED);
+    }
+
+    @Test
+    public void testCheckParametersRequiredRequiredExtraFails() {
+        this.checkParametersFails(2, REQUIRED);
+    }
+
+    @Test
+    public void testCheckParametersOptional() {
+        this.checkParameters(1, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersOptionalMissing() {
+        this.checkParameters(0, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersOptionalOptionalMissingMissing() {
+        this.checkParameters(0, OPTIONAL, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersOptionalOptionalPresentMissing() {
+        this.checkParameters(1, OPTIONAL, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersOptionalOptionalPresentPresent() {
+        this.checkParameters(2, OPTIONAL, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersOptionalOptionalPresentPresentExtraFails() {
+        this.checkParametersFails(3, OPTIONAL, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersVariableNone() {
+        this.checkParameters(0, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersVariable() {
+        this.checkParameters(1, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersVariable2() {
+        this.checkParameters(2, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersRequiredVariable0Fails() {
+        this.checkParametersFails(0, REQUIRED, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersRequiredVariable1() {
+        this.checkParameters(1, REQUIRED, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersRequiredVariable2() {
+        this.checkParameters(2, REQUIRED, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersRequiredVariable3() {
+        this.checkParameters(3, REQUIRED, VARIABLE);
+    }
+
+    @Test
+    public void testCheckParametersRequiredOptional0Fails() {
+        this.checkParametersFails(0, REQUIRED, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersRequiredOptional1() {
+        this.checkParameters(1, REQUIRED, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersRequiredOptional2() {
+        this.checkParameters(2, REQUIRED, OPTIONAL);
+    }
+
+    @Test
+    public void testCheckParametersRequiredOptional3Fails() {
+        this.checkParametersFails(3, REQUIRED, OPTIONAL);
+    }
+
+    private void checkParameters(final int count,
+                                 final ExpressionFunctionParameter<?>... parameters) {
         new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
             @Override
             public List<ExpressionFunctionParameter<?>> parameters() {
-                return ExpressionFunctionParameter.list(
-                        ExpressionFunctionParameterName.with("first").setType(Integer.class),
-                        ExpressionFunctionParameterName.with("second").setType(Integer.class)
-                );
+                return Lists.of(parameters);
             }
-        }.checkOnlyRequiredParameters(Lists.of(1, 2));
+        }.checkParameterCount(Collections.nCopies(count, null));
     }
 
-    @Test
-    public void testCheckOnlyRequiredParametersMoreFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
-                        @Override
-                        public List<ExpressionFunctionParameter<?>> parameters() {
-                            return ExpressionFunctionParameter.list(
-                                    ExpressionFunctionParameterName.with("first").setType(Integer.class)
-                            );
-                        }
-                    }.checkOnlyRequiredParameters(Lists.of(1, 2));
-                });
-    }
 
-    // checkWithoutExtraParameters.....................................................................................
+    private void checkParametersFails(final int count,
+                                      final ExpressionFunctionParameter<?>... parameters) {
+        boolean failed = false;
 
-    @Test
-    public void testCheckWithoutExtraParametersLess() {
-        new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
-            @Override
-            public List<ExpressionFunctionParameter<?>> parameters() {
-                return ExpressionFunctionParameter.list(
-                        ExpressionFunctionParameterName.with("first").setType(Integer.class),
-                        ExpressionFunctionParameterName.with("second").setType(Integer.class)
-                );
-            }
-        }.checkWithoutExtraParameters(Lists.of(1));
-    }
-
-    @Test
-    public void testCheckWithoutExtraParametersSame() {
-        new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
-            @Override
-            public List<ExpressionFunctionParameter<?>> parameters() {
-                return ExpressionFunctionParameter.list(
-                        ExpressionFunctionParameterName.with("first").setType(Integer.class),
-                        ExpressionFunctionParameterName.with("second").setType(Integer.class)
-                );
-            }
-        }.checkWithoutExtraParameters(Lists.of(1, 2));
-    }
-
-    @Test
-    public void testCheckWithoutExtraParametersMoreFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
-                        @Override
-                        public List<ExpressionFunctionParameter<?>> parameters() {
-                            return ExpressionFunctionParameter.list(
-                                    ExpressionFunctionParameterName.with("first").setType(Integer.class)
-                            );
-                        }
-                    }.checkWithoutExtraParameters(Lists.of(1, 2));
-                });
+        try {
+            this.checkParameters(count, parameters);
+        } catch (final IllegalArgumentException expected) {
+            failed = true;
+        }
+        this.checkEquals(true, failed);
     }
 
     // convertParameters ...............................................................................................
 
-    private final static ExpressionFunctionParameter<Integer> INTEGER = ExpressionFunctionParameterName.with("integer").setType(Integer.class);
+    private final static ExpressionFunctionParameter<Integer> INTEGER_REQUIRED = ExpressionFunctionParameterName.with("integer").required(Integer.class);
 
-    private final static ExpressionFunctionParameter<Boolean> BOOLEAN = ExpressionFunctionParameterName.with("boolean").setType(Boolean.class);
+    private static final ExpressionFunctionParameter<Integer> INTEGER_VARIABLE = INTEGER_REQUIRED.name()
+            .variable(Integer.class);
+
+    private final static ExpressionFunctionParameter<Boolean> BOOLEAN = ExpressionFunctionParameterName.with("boolean").required(Boolean.class);
 
     @Test
     public void testConvertParametersCorrectParameterCount() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER),
-                false,
+                Lists.of(INTEGER_REQUIRED),
                 Lists.of("123"),
                 Lists.of(123)
         );
@@ -141,8 +189,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersCorrectParameterCount2() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER, BOOLEAN),
-                false,
+                Lists.of(INTEGER_REQUIRED, BOOLEAN),
                 Lists.of("123", "true"),
                 Lists.of(123, true)
         );
@@ -151,8 +198,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersCorrectParameterCountLastParameterVariable() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER),
-                true,
+                Lists.of(INTEGER_VARIABLE),
                 Lists.of("123", "456"),
                 Lists.of(123, 456)
         );
@@ -161,8 +207,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersCorrectParameterCountLastParameterVariable2() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER),
-                true,
+                Lists.of(INTEGER_VARIABLE),
                 Lists.of("123", "456", "678"),
                 Lists.of(123, 456, 678)
         );
@@ -171,8 +216,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersCorrectParameterCountLastParameterVariable3() {
         this.convertParametersAndCheck(
-                Lists.of(BOOLEAN, INTEGER),
-                true,
+                Lists.of(BOOLEAN, INTEGER_VARIABLE),
                 Lists.of("true", "456", "678"),
                 Lists.of(true, 456, 678)
         );
@@ -182,7 +226,6 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     public void testConvertParametersMissingParameterInfos() {
         this.convertParametersAndCheck(
                 Lists.empty(),
-                false,
                 Lists.of("abc"),
                 Lists.of("abc")
         );
@@ -191,8 +234,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersMissingParameterInfos2() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER),
-                false,
+                Lists.of(INTEGER_REQUIRED),
                 Lists.of("123", "abc"),
                 Lists.of(123, "abc")
         );
@@ -201,8 +243,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersMissingParameterInfos3() {
         this.convertParametersAndCheck(
-                Lists.of(INTEGER, BOOLEAN),
-                false,
+                Lists.of(INTEGER_REQUIRED, BOOLEAN),
                 Lists.of("123", "true", "abc"),
                 Lists.of(123, true, "abc")
         );
@@ -212,7 +253,6 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     public void testConvertParametersNullParameterInfoFails() {
         this.convertParametersAndFail(
                 Lists.of(new ExpressionFunctionParameter[]{null}),
-                false,
                 Lists.of("123"),
                 NullPointerException.class
         );
@@ -221,8 +261,7 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersNullParameterInfoFails2() {
         this.convertParametersAndFail(
-                Lists.of(INTEGER, null),
-                false,
+                Lists.of(INTEGER_REQUIRED, null),
                 Lists.of("123", "456"),
                 NullPointerException.class
         );
@@ -231,38 +270,34 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
     @Test
     public void testConvertParametersConvertFails2() {
         this.convertParametersAndFail(
-                Lists.of(INTEGER, null),
-                false,
+                Lists.of(INTEGER_REQUIRED, null),
                 Lists.of("xyz"),
                 NumberFormatException.class
         );
     }
 
     private void convertParametersAndCheck(final List<ExpressionFunctionParameter<?>> parameterInfos,
-                                           final boolean lsLastParameterVariable,
                                            final List<Object> beforeValues,
                                            final List<Object> afterValues) {
         this.checkEquals(
                 afterValues,
-                this.convertParameters(parameterInfos, lsLastParameterVariable, beforeValues),
+                this.convertParameters(parameterInfos, beforeValues),
                 () -> "convertParameters " + beforeValues + " " + parameterInfos
         );
     }
 
     private void convertParametersAndFail(final List<ExpressionFunctionParameter<?>> parameterInfos,
-                                          final boolean lsLastParameterVariable,
                                           final List<Object> beforeValues,
                                           final Class<? extends Throwable> thrown) {
         assertThrows(
                 thrown,
                 () -> {
-                    this.convertParameters(parameterInfos, lsLastParameterVariable, beforeValues);
+                    this.convertParameters(parameterInfos, beforeValues);
                 }
         );
     }
 
     private List<Object> convertParameters(final List<ExpressionFunctionParameter<?>> parameterInfos,
-                                           final boolean lsLastParameterVariable,
                                            final List<Object> beforeValues) {
         return
                 new FakeExpressionFunction<Void, FakeExpressionFunctionContext>() {
@@ -271,10 +306,6 @@ public final class ExpressionFunctionTest implements ClassTesting<ExpressionFunc
                         return parameterInfos;
                     }
 
-                    @Override
-                    public boolean lsLastParameterVariable() {
-                        return lsLastParameterVariable;
-                    }
                 }.convertParameters(
                         beforeValues,
                         new FakeExpressionFunctionContext() {

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestingTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionTestingTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -177,6 +178,214 @@ public final class ExpressionFunctionTestingTest implements ClassTesting<Express
                         .collect(Collectors.joining());
             }
         };
+    }
+
+    // testParameterNamesUnique.........................................................................................
+
+    @Test
+    public void testTestParameterNamesUnique() {
+        new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+            @Override
+            public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                return new FakeExpressionFunction<>() {
+                    @Override
+                    public List<ExpressionFunctionParameter<?>> parameters() {
+                        return Lists.of(
+                                ExpressionFunctionParameter.BOOLEAN,
+                                ExpressionFunctionParameter.CHARACTER,
+                                ExpressionFunctionParameter.DATE
+                        );
+                    }
+                };
+            }
+
+            @Override
+            public FakeExpressionFunctionContext createContext() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                throw new UnsupportedOperationException();
+            }
+        }.testParameterNamesUnique();
+    }
+
+    @Test
+    public void testTestParameterNamesUniqueDuplicatesFail() {
+        boolean fail = false;
+
+        try {
+            new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+                @Override
+                public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                    return new FakeExpressionFunction<>() {
+                        @Override
+                        public List<ExpressionFunctionParameter<?>> parameters() {
+                            return Lists.of(
+                                    ExpressionFunctionParameter.BOOLEAN,
+                                    ExpressionFunctionParameter.CHARACTER,
+                                    ExpressionFunctionParameter.BOOLEAN
+                            );
+                        }
+                    };
+                }
+
+                @Override
+                public FakeExpressionFunctionContext createContext() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                    throw new UnsupportedOperationException();
+                }
+            }.testParameterNamesUnique();
+        } catch (final AssertionError expected) {
+            fail = true;
+        }
+
+        this.checkEquals(true, fail);
+    }
+
+    // testParametersOptionalNotBeforeRequired.........................................................................
+
+    @Test
+    public void testParametersOptionalNotBeforeRequired() {
+        new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+            @Override
+            public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                return new FakeExpressionFunction<>() {
+                    @Override
+                    public List<ExpressionFunctionParameter<?>> parameters() {
+                        return Lists.of(
+                                ExpressionFunctionParameterName.BOOLEAN.required(Boolean.class),
+                                ExpressionFunctionParameterName.CHARACTER.optional(Character.class)
+                        );
+                    }
+                };
+            }
+
+            @Override
+            public FakeExpressionFunctionContext createContext() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                throw new UnsupportedOperationException();
+            }
+        }.testParametersOptionalNotBeforeRequired();
+    }
+
+    @Test
+    public void testParametersOptionalNotBeforeRequiredFails() {
+        boolean fail = false;
+
+        try {
+            new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+                @Override
+                public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                    return new FakeExpressionFunction<>() {
+                        @Override
+                        public List<ExpressionFunctionParameter<?>> parameters() {
+                            return Lists.of(
+                                    ExpressionFunctionParameterName.BOOLEAN.required(Boolean.class),
+                                    ExpressionFunctionParameterName.CHARACTER.optional(Character.class),
+                                    ExpressionFunctionParameterName.DATE.required(LocalDate.class)
+                            );
+                        }
+                    };
+                }
+
+                @Override
+                public FakeExpressionFunctionContext createContext() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                    throw new UnsupportedOperationException();
+                }
+            }.testParametersOptionalNotBeforeRequired();
+        } catch (final AssertionError expected) {
+            fail = true;
+        }
+
+        this.checkEquals(true, fail);
+    }
+
+    // testParametersOnlyLastMayBeVariable..............................................................................
+
+    @Test
+    public void testParametersOnlyLastMayBeVariable() {
+        new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+            @Override
+            public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                return new FakeExpressionFunction<>() {
+                    @Override
+                    public List<ExpressionFunctionParameter<?>> parameters() {
+                        return Lists.of(
+                                ExpressionFunctionParameterName.BOOLEAN.required(Boolean.class),
+                                ExpressionFunctionParameterName.CHARACTER.variable(Character.class)
+                        );
+                    }
+                };
+            }
+
+            @Override
+            public FakeExpressionFunctionContext createContext() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                throw new UnsupportedOperationException();
+            }
+        }.testParametersOnlyLastMayBeVariable();
+    }
+
+    @Test
+    public void testParametersOnlyLastMayBeVariableFails() {
+        boolean fail = false;
+
+        try {
+            new ExpressionFunctionTesting<FakeExpressionFunction<Void, FakeExpressionFunctionContext>, Void, FakeExpressionFunctionContext>() {
+
+                @Override
+                public FakeExpressionFunction<Void, FakeExpressionFunctionContext> createBiFunction() {
+                    return new FakeExpressionFunction<>() {
+                        @Override
+                        public List<ExpressionFunctionParameter<?>> parameters() {
+                            return Lists.of(
+                                    ExpressionFunctionParameterName.BOOLEAN.required(Boolean.class),
+                                    ExpressionFunctionParameterName.CHARACTER.variable(Character.class),
+                                    ExpressionFunctionParameterName.DATE.required(LocalDate.class)
+                            );
+                        }
+                    };
+                }
+
+                @Override
+                public FakeExpressionFunctionContext createContext() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Class<FakeExpressionFunction<Void, FakeExpressionFunctionContext>> type() {
+                    throw new UnsupportedOperationException();
+                }
+            }.testParametersOnlyLastMayBeVariable();
+        } catch (final AssertionError expected) {
+            fail = true;
+        }
+
+        this.checkEquals(true, fail);
     }
 
     // requiresEvaluatedParameters.....................................................................................

--- a/src/test/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ParametersMapperExpressionFunctionTest.java
@@ -64,7 +64,7 @@ public final class ParametersMapperExpressionFunctionTest implements ExpressionF
         @Override
         public List<ExpressionFunctionParameter<?>> parameters() {
             return Lists.of(
-                    ExpressionFunctionParameterName.with("parameter1").setType(String.class)
+                    ExpressionFunctionParameterName.with("parameter1").required(String.class)
             );
         }
 

--- a/src/test/java/walkingkooka/tree/sample/Sample.java
+++ b/src/test/java/walkingkooka/tree/sample/Sample.java
@@ -64,7 +64,7 @@ public final class Sample {
     }
 
     public void testExpressionFunctionParameterGetOrFail() {
-        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameterName.with("test123").setType(Integer.class);
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameterName.with("test123").required(Integer.class);
         assertEquals(
                 100,
                 parameter.getOrFail(


### PR DESCRIPTION
- all parameters now have a cardinality property.
- ExpressionFunction.checkParameterCount honours parameter cardinality
- ExpressionFunction.checkOnlyRequiredParameters, checkWithoutExtraParameters removed
- ExpressionFunction.lsLastParameterVariable() removed

- Closes https://github.com/mP1/walkingkooka-tree/issues/383
- ExpressionFunctionParameter.cardinality