### PR TITLE
ExpressionNumber.xxxValueExact

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
@@ -311,23 +311,13 @@ public abstract class ExpressionNumber extends Number implements Comparable<Expr
 
     // toXXX............................................................................................................
 
-    @Override
-    public abstract byte byteValue();
+    public abstract byte byteValueExact();
 
-    @Override
-    public abstract short shortValue();
+    public abstract short shortValueExact();
 
-    @Override
-    public abstract int intValue();
+    public abstract int intValueExact();
 
-    @Override
-    public abstract long longValue();
-
-    @Override
-    public abstract float floatValue();
-
-    @Override
-    public abstract double doubleValue();
+    public abstract long longValueExact();
 
     public abstract BigInteger bigInteger();
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
@@ -203,21 +203,41 @@ final class ExpressionNumberBigDecimal extends ExpressionNumber {
 
     @Override
     public byte byteValue() {
+        return this.value.byteValue();
+    }
+
+    @Override
+    public byte byteValueExact() {
         return this.value.byteValueExact();
     }
 
     @Override
     public short shortValue() {
+        return this.value.shortValue();
+    }
+
+    @Override
+    public short shortValueExact() {
         return this.value.shortValueExact();
     }
 
     @Override
     public int intValue() {
+        return this.value.intValue();
+    }
+
+    @Override
+    public int intValueExact() {
         return this.value.intValueExact();
     }
 
     @Override
     public long longValue() {
+        return this.value.longValue();
+    }
+
+    @Override
+    public long longValueExact() {
         return this.value.longValueExact();
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
@@ -194,6 +194,11 @@ final class ExpressionNumberDouble extends ExpressionNumber {
 
     @Override
     public byte byteValue() {
+        return (byte) this.value;
+    }
+
+    @Override
+    public byte byteValueExact() {
         final byte value = (byte) this.value;
         this.failIfDifferent(value, "byteValue");
         return value;
@@ -201,6 +206,11 @@ final class ExpressionNumberDouble extends ExpressionNumber {
 
     @Override
     public short shortValue() {
+        return (short) this.value;
+    }
+
+    @Override
+    public short shortValueExact() {
         final short value = (short) this.value;
         this.failIfDifferent(value, "shortValue");
         return value;
@@ -208,6 +218,11 @@ final class ExpressionNumberDouble extends ExpressionNumber {
 
     @Override
     public int intValue() {
+        return (int) this.value;
+    }
+
+    @Override
+    public int intValueExact() {
         final int value = (int) this.value;
         this.failIfDifferent(value, "intValue");
         return value;
@@ -215,6 +230,11 @@ final class ExpressionNumberDouble extends ExpressionNumber {
 
     @Override
     public long longValue() {
+        return (long) this.value;
+    }
+
+    @Override
+    public long longValueExact() {
         final long value = (long) this.value;
         this.failIfDifferent(value, "longValue");
         return value;

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
@@ -868,74 +868,183 @@ public abstract class ExpressionNumberTestCase<N extends ExpressionNumber> imple
     @Test
     public final void testByteValue() {
         final byte value = 1;
-        this.checkEquals(value, this.create(value).byteValue());
+        this.checkEquals(
+                value,
+                this.create(value).byteValue()
+        );
     }
 
     @Test
-    public final void testByteValueFails() {
-        assertThrows(ArithmeticException.class, () -> this.create(1.5).byteValue());
+    public final void testByteValueDecimal() {
+        this.checkEquals(
+                (byte) 1,
+                this.create(1.5).byteValue()
+        );
+    }
+
+    // byteValueExact..................................................................................................
+
+    @Test
+    public final void testByteValueExact() {
+        final byte value = 1;
+        this.checkEquals(
+                value,
+                this.create(value).byteValueExact()
+        );
     }
 
     @Test
-    public final void testByteValueFails2() {
-        assertThrows(ArithmeticException.class, () -> this.create(Short.MAX_VALUE).byteValue());
+    public final void testByteValueExactFails() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(1.5).byteValueExact()
+        );
     }
 
-    // shortValue.......................................................................................................
+    @Test
+    public final void testByteValueExactFails2() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(Short.MAX_VALUE).byteValueExact()
+        );
+    }
+
+    // shortValue........................................................................................................
 
     @Test
     public final void testShortValue() {
         final short value = 1;
-        this.checkEquals(value, this.create(value).shortValue());
+        this.checkEquals(
+                value,
+                this.create(value).shortValue()
+        );
     }
 
     @Test
-    public final void testShortValueFails() {
-        assertThrows(ArithmeticException.class, () -> this.create(1.5).shortValue());
+    public final void testShortValueDecimal() {
+        this.checkEquals(
+                (short) 1,
+                this.create(1.5).shortValue()
+        );
+    }
+
+    // shortValueExact..................................................................................................
+
+    @Test
+    public final void testShortValueExact() {
+        final short value = 1;
+        this.checkEquals(
+                value,
+                this.create(value).shortValueExact()
+        );
     }
 
     @Test
-    public final void testShortValueFails2() {
-        assertThrows(ArithmeticException.class, () -> this.create(Integer.MAX_VALUE).shortValue());
+    public final void testShortValueExactFails() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(1.5).shortValueExact()
+        );
     }
 
-    // intValue.......................................................................................................
+    @Test
+    public final void testShortValueExactFails2() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(Integer.MAX_VALUE).shortValueExact()
+        );
+    }
+
+    // intValue........................................................................................................
 
     @Test
     public final void testIntValue() {
         final int value = 1;
-        this.checkEquals(value, this.create(value).intValue());
+        this.checkEquals(
+                value,
+                this.create(value).intValue()
+        );
     }
 
     @Test
-    public final void testIntValueFails() {
-        assertThrows(ArithmeticException.class, () -> this.create(1.5).intValue());
+    public final void testIntValueDecimal() {
+        this.checkEquals(
+                (int) 1,
+                this.create(1.5).intValue()
+        );
+    }
+
+    // intValueExact....................................................................................................
+
+    @Test
+    public final void testIntValueExact() {
+        final int value = 1;
+        this.checkEquals(
+                value,
+                this.create(value).intValueExact()
+        );
     }
 
     @Test
-    public final void testIntValueFails2() {
-        assertThrows(ArithmeticException.class, () -> this.create(Long.MAX_VALUE).intValue());
+    public final void testIntValueExactFails() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(1.5).intValueExact()
+        );
     }
 
-    // longValue.......................................................................................................
+    @Test
+    public final void testIntValueExactFails2() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(Long.MAX_VALUE).intValueExact()
+        );
+    }
+
+    // longValue........................................................................................................
 
     @Test
     public final void testLongValue() {
-        final int value = 1;
+        final long value = 1;
         this.checkEquals(
-                (long) value,
+                value,
                 this.create(value).longValue()
         );
     }
 
     @Test
-    public final void testLongValueFails() {
-        assertThrows(ArithmeticException.class, () -> this.create(1.5).longValue());
+    public final void testLongValueDecimal() {
+        this.checkEquals(
+                (long) 1,
+                this.create(1.5).longValue()
+        );
+    }
+
+    // longValueExact...................................................................................................
+
+    @Test
+    public final void testLongValueExact() {
+        final int value = 1;
+        this.checkEquals(
+                (long) value,
+                this.create(value).longValueExact()
+        );
     }
 
     @Test
-    public final void testLongValueFails2() {
-        assertThrows(ArithmeticException.class, () -> this.create(Double.MAX_VALUE).longValue());
+    public final void testLongValueExactFails() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(1.5).longValueExact()
+        );
+    }
+
+    @Test
+    public final void testLongValueExactFails2() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(Double.MAX_VALUE).longValueExact()
+        );
     }
 
     // floatValue.......................................................................................................

--- a/src/test/java/walkingkooka/tree/expression/NotExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/NotExpressionTest.java
@@ -24,7 +24,6 @@ import walkingkooka.visit.Visiting;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class NotExpressionTest extends UnaryExpressionTestCase<NotExpression> {
 
@@ -85,11 +84,6 @@ public final class NotExpressionTest extends UnaryExpressionTestCase<NotExpressi
     public void testEvaluateToExpressionNumber() {
         final long value = 123;
         this.evaluateAndCheckExpressionNumber(this.createExpression(expressionNumber(value)), ~value);
-    }
-
-    @Test
-    public void testEvaluateToExpressionNumberWithDecimalsFails() {
-        assertThrows(ArithmeticException.class, () -> this.createExpression(expressionNumber(1.5)).toExpressionNumber(context()));
     }
 
     @Override


### PR DESCRIPTION
- xxxValue() methods no longer fail on decimals, now simply chop.

- Closes https://github.com/mP1/walkingkooka-tree/issues/393
- ExpressionNumber.byteValueExact/shortValueExact/intValueExact/longValueExact