### PR TITLE
ExpressionNumber.bigIntegerExact

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
@@ -321,6 +321,8 @@ public abstract class ExpressionNumber extends Number implements Comparable<Expr
 
     public abstract BigInteger bigInteger();
 
+    public abstract BigInteger bigIntegerExact();
+
     public abstract BigDecimal bigDecimal();
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
@@ -253,6 +253,11 @@ final class ExpressionNumberBigDecimal extends ExpressionNumber {
 
     @Override
     public BigInteger bigInteger() {
+        return this.value.toBigInteger();
+    }
+
+    @Override
+    public BigInteger bigIntegerExact() {
         return this.value.toBigIntegerExact();
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
@@ -259,7 +259,14 @@ final class ExpressionNumberDouble extends ExpressionNumber {
 
     @Override
     public BigInteger bigInteger() {
-        return this.bigDecimal().toBigIntegerExact();
+        return this.bigDecimal()
+                .toBigInteger();
+    }
+
+    @Override
+    public BigInteger bigIntegerExact() {
+        return this.bigDecimal()
+                .toBigIntegerExact();
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
@@ -1077,6 +1077,27 @@ public abstract class ExpressionNumberTestCase<N extends ExpressionNumber> imple
         this.checkEquals(BigInteger.valueOf(value), this.create(value).bigInteger());
     }
 
+
+    // bigIntegerExact.......................................................................................................
+
+    @Test
+    public final void testBigIntegerExact() {
+        final int value = 1;
+        this.checkEquals(
+                BigInteger.valueOf(value),
+                this.create(value).bigIntegerExact()
+        );
+    }
+
+    @Test
+    public final void testBigIntegerExactDecimalFails() {
+        assertThrows(
+                ArithmeticException.class,
+                () -> this.create(1.5)
+                        .bigIntegerExact()
+        );
+    }
+
     // bigDecimal.......................................................................................................
 
     @Test


### PR DESCRIPTION
- ExpressionNumber.bigInteger no longer fails when decimals present.