### PR TITLE
ExpressionEvaluationContext requireParameters & resolveReferences

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -17,8 +17,10 @@
 
 package walkingkooka.tree.expression;
 
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -31,6 +33,19 @@ public interface ExpressionEvaluationContext extends ExpressionFunctionContext,
      * Evaluate the given {@link Expression} returning the result/value.
      */
     Object evaluate(final Expression expression);
+
+    /**
+     * Accepts a function and its parameters and returns a List view of those parameters honouring
+     * the {@link ExpressionFunction#requiresEvaluatedParameters()} and {@link ExpressionFunction#resolveReferences()}.
+     */
+    default List<Object> prepareParameters(final ExpressionFunction<?, ExpressionFunctionContext> function,
+                                           final List<Object> parameters) {
+        return ExpressionEvaluationContextParametersList.with(
+                parameters,
+                function,
+                this
+        );
+    }
 
     /**
      * Locates the value or a {@link Expression} for the given {@link ExpressionReference}

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextParametersList.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextParametersList.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Wraps the {@link List} of parameters, lazily resolving each parameter to a value required by the function,
+ * and lazily resolving references as well.
+ */
+final class ExpressionEvaluationContextParametersList extends AbstractList<Object> {
+
+    static ExpressionEvaluationContextParametersList with(final List<Object> parameters,
+                                                          final ExpressionFunction<?, ExpressionFunctionContext> function,
+                                                          final ExpressionEvaluationContext context) {
+        return new ExpressionEvaluationContextParametersList(
+                parameters,
+                function,
+                context
+        );
+    }
+
+    private ExpressionEvaluationContextParametersList(final List<Object> parameters,
+                                                      final ExpressionFunction<?, ExpressionFunctionContext> function,
+                                                      final ExpressionEvaluationContext context) {
+        this.parameters = parameters.toArray(new Object[parameters.size()]);
+
+        this.function = function;
+        this.context = context;
+    }
+
+    @Override
+    public Object get(final int index) {
+        final Object[] parameters = this.parameters;
+
+        Object parameter = parameters[index];
+
+        if (parameter instanceof Expression) {
+            if (this.function.requiresEvaluatedParameters()) {
+                parameter = toReferenceOrValue(parameter);
+                parameters[index] = parameter;
+            }
+        }
+            if (parameter instanceof ExpressionReference) {
+                if (this.function.resolveReferences()) {
+                    parameter = this.context.referenceOrFail((ExpressionReference) parameter);
+
+                    if (parameter instanceof Expression && this.function.requiresEvaluatedParameters()) {
+                        parameter = toReferenceOrValue(parameter);
+                    }
+                    parameters[index] = parameter;
+                }
+            }
+
+        return parameter;
+    }
+
+    private Object toReferenceOrValue(final Object parameter) {
+        final Expression expression = (Expression) parameter;
+        return expression.toReferenceOrValue(this.context);
+    }
+
+    /**
+     * The function these parameters belong too. The function will provide numerous parameters about how to prepare the
+     * parameters if at all.
+     */
+    private final ExpressionFunction<?, ExpressionFunctionContext> function;
+
+    /**
+     * {@link ExpressionEvaluationContext context} used to resolve references and evaluate parameters to values.
+     */
+    private final ExpressionEvaluationContext context;
+
+    @Override
+    public int size() {
+        return this.parameters.length;
+    }
+
+    /**
+     * A copy of the original parameters, as an array, where elements are overwritten as values are evaluated or
+     * references resolved.
+     */
+    private final Object[] parameters;
+
+    @Override
+    public String toString() {
+        return Arrays.toString(this.parameters);
+    }
+}

--- a/src/main/java/walkingkooka/tree/expression/FunctionExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/FunctionExpression.java
@@ -18,8 +18,6 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.Cast;
-import walkingkooka.tree.expression.function.ExpressionFunction;
-import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.visit.Visiting;
 
 import java.time.LocalDate;
@@ -27,8 +25,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Represents a function with zero or more parameters.
@@ -152,37 +148,20 @@ public final class FunctionExpression extends VariableExpression {
     }
 
     private Object executeFunction(final ExpressionEvaluationContext context) {
-        final ExpressionFunction<?, ExpressionFunctionContext> function = context.function(this.name());
-
         return this.executeFunction0(
-                function,
                 this.value(),
                 context
         );
     }
 
-    private Object executeFunction0(final ExpressionFunction<?, ExpressionFunctionContext> function,
-                                    final List<Expression> parameters,
+    /**
+     * Delegates to the given context.
+     */
+    private Object executeFunction0(final List<Expression> parameters,
                                     final ExpressionEvaluationContext context) {
-        final List<Object> preparedParameters;
-
-        if (function.requiresEvaluatedParameters()) {
-            final Function<Expression, Object> mapper = function.resolveReferences() ?
-                    (e) -> e.toValue(context) :
-                    (e) -> e.toReferenceOrValue(context);
-            preparedParameters = this.value()
-                    .stream()
-                    .map(mapper)
-                    .collect(
-                            Collectors.toList()
-                    );
-        } else {
-            preparedParameters = Cast.to(parameters);
-        }
-
         return context.evaluate(
                 this.name(),
-                preparedParameters
+                Cast.to(parameters)
         );
     }
 

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -111,11 +111,18 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
         return expression.toValue(this);
     }
 
+    /**
+     * Before invoking the function identified by the given {@link FunctionExpressionName} parameters are resolved
+     */
     @Override
     public Object evaluate(final FunctionExpressionName name,
                            final List<Object> parameters) {
-        return this.function(name)
-                .apply(parameters, this);
+        final ExpressionFunction<?, ExpressionFunctionContext> function = this.function(name);
+
+        return function.apply(
+                this.prepareParameters(function, parameters),
+                this
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextParametersListTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextParametersListTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.ListTesting;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+import walkingkooka.tree.expression.function.FakeExpressionFunction;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class ExpressionEvaluationContextParametersListTest implements ClassTesting<ExpressionEvaluationContextParametersList>,
+        ListTesting {
+
+    private final static ExpressionReference REFERENCE = new ExpressionReference() {
+        @Override
+        public String toString() {
+            return "*reference*";
+        }
+    };
+
+    @Test
+    public void testSize() {
+        final Object element1 = 111;
+        final Object element2 = Expression.value("222");
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(false, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+    }
+
+    @Test
+    public void testObjectRequiresEvaluatedParametersFalse() {
+        final Object element1 = 111;
+        final Object element2 = "222";
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(false, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, element1);
+        this.getAndCheck(list, 1, element2);
+    }
+
+    @Test
+    public void testExpressionRequiresEvaluatedParametersFalse() {
+        final Expression element1 = Expression.value(111);
+        final Expression element2 = Expression.value("222");
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(false, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, element1);
+        this.getAndCheck(list, 1, element2);
+    }
+
+    @Test
+    public void testObjectRequiresEvaluatedParametersTrue() {
+        final Object element1 = 111;
+        final Object element2 = "222";
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(true, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, element1);
+        this.getAndCheck(list, 1, element2);
+    }
+
+    @Test
+    public void testExpressionRequiresEvaluatedParametersTrue() {
+        final ValueExpression<?> element1 = Expression.value(111);
+        final ValueExpression<?> element2 = Expression.value("222");
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(true, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, element1.value());
+        this.getAndCheck(list, 1, element2.value());
+    }
+
+    @Test
+    public void testObjectResolveReferencesTrue() {
+        final Object element1 = 111;
+        final Object element2 = "222";
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(true, false),
+                ExpressionEvaluationContexts.fake()
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, element1);
+        this.getAndCheck(list, 1, element2);
+    }
+
+    @Test
+    public void testExpressionReferenceResolveReferencesTrue() {
+        final ExpressionReference element1 = REFERENCE;
+        final ValueExpression<?> value1 = Expression.value(111);
+        final ValueExpression<?> element2 = Expression.value("222");
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(false, true),
+                new FakeExpressionEvaluationContext() {
+                    @Override
+                    public Expression referenceOrFail(final ExpressionReference r) {
+                        assertSame(REFERENCE, r);
+                        return value1;
+                    }
+                }
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, value1);
+        this.getAndCheck(list, 1, element2);
+    }
+
+    @Test
+    public void testExpressionReferenceResolveReferencesTrueRequireParametersEvaluated() {
+        final ExpressionReference element1 = REFERENCE;
+        final ValueExpression<?> value1 = Expression.value(111);
+        final ValueExpression<?> element2 = Expression.value("222");
+
+        final List<Object> parameters = Lists.of(
+                element1,
+                element2
+        );
+        final ExpressionEvaluationContextParametersList list = ExpressionEvaluationContextParametersList.with(
+                parameters,
+                this.function(true, true),
+                new FakeExpressionEvaluationContext() {
+                    @Override
+                    public Expression referenceOrFail(final ExpressionReference r) {
+                        assertSame(REFERENCE, r);
+                        return value1;
+                    }
+                }
+        );
+
+        this.sizeAndCheck(list, 2);
+        this.getAndCheck(list, 0, value1.value());
+        this.getAndCheck(list, 1, element2.value());
+    }
+
+    private ExpressionFunction<Void, ExpressionFunctionContext> function(final boolean requiresEvaluatedParameters,
+                                                                         final boolean resolveReferences) {
+        return new FakeExpressionFunction<>() {
+            @Override
+            public boolean requiresEvaluatedParameters() {
+                return requiresEvaluatedParameters;
+            }
+
+            @Override
+            public boolean resolveReferences() {
+                return resolveReferences;
+            }
+
+            @Override
+            public String toString() {
+                return "requiresEvaluatedParameters: " + requiresEvaluatedParameters + " resolveReferences: " + resolveReferences;
+            }
+        };
+    }
+
+    // ClassTesting....................................................................................................
+
+    @Override
+    public Class<ExpressionEvaluationContextParametersList> type() {
+        return ExpressionEvaluationContextParametersList.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/tree/expression/FunctionExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/FunctionExpressionTest.java
@@ -31,7 +31,6 @@ import walkingkooka.visit.Visiting;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -144,110 +143,6 @@ public final class FunctionExpressionTest extends VariableExpressionTestCase<Fun
         );
     }
 
-    @Test
-    public void testToValueFunctionRequiresEvaluatedParametersTrueResolveReferencesTrue() {
-        final StringName attribute = Names.string("attribute123");
-        final String value = "value-345";
-        final ExpressionReference reference = NodeSelectorAttributeName.with(attribute.value());
-
-        final List<Expression> parameters = Lists.of(
-                Expression.value("1"),
-                Expression.reference(reference)
-        );
-
-        this.checkEquals(
-                Lists.of("1", value),
-                Expression.function(FUNCTION_NAME, parameters)
-                        .toValue(
-                                new FakeExpressionEvaluationContext() {
-                                    @Override
-                                    public ExpressionFunction<?, ExpressionFunctionContext> function(final FunctionExpressionName name) {
-                                        checkEquals(FUNCTION_NAME, name, "function name");
-                                        return new FakeExpressionFunction<>() {
-                                            @Override
-                                            public Object apply(final List<Object> parameters,
-                                                                final ExpressionFunctionContext contet) {
-                                                return parameters;
-                                            }
-
-                                            @Override
-                                            public boolean requiresEvaluatedParameters() {
-                                                return true;
-                                            }
-
-                                            @Override
-                                            public boolean resolveReferences() {
-                                                return true;
-                                            }
-                                        };
-                                    }
-
-                                    public Object evaluate(final FunctionExpressionName name, final List<Object> parameters) {
-                                        Objects.requireNonNull(name, "name");
-                                        Objects.requireNonNull(parameters, "parameters");
-
-                                        return this.function(name).apply(parameters, this);
-                                    }
-
-                                    @Override
-                                    public Optional<Expression> reference(final ExpressionReference r) {
-                                        assertSame(reference, r, "reference");
-                                        return Optional.of(Expression.value(value));
-                                    }
-                                }
-                        )
-        );
-    }
-
-    @Test
-    public void testToValueFunctionRequiresEvaluatedParametersTrueResolveReferencesFalse() {
-        final StringName attribute = Names.string("attribute123");
-        final ExpressionReference reference = NodeSelectorAttributeName.with(attribute.value());
-
-        final List<Expression> parameters = Lists.of(
-                Expression.value("1"),
-                Expression.reference(reference)
-        );
-
-        this.checkEquals(
-                Lists.of("1", reference),
-                Expression.function(FUNCTION_NAME, parameters)
-                        .toValue(
-                                new FakeExpressionEvaluationContext() {
-                                    @Override
-                                    public ExpressionFunction<?, ExpressionFunctionContext> function(final FunctionExpressionName name) {
-                                        checkEquals(FUNCTION_NAME, name, "function name");
-                                        return new FakeExpressionFunction<>() {
-
-                                            @Override
-                                            public Object apply(final List<Object> parameters,
-                                                                final ExpressionFunctionContext context) {
-                                                return parameters;
-                                            }
-
-                                            @Override
-                                            public boolean requiresEvaluatedParameters() {
-                                                return true;
-                                            }
-
-                                            @Override
-                                            public boolean resolveReferences() {
-                                                return false;
-                                            }
-                                        };
-                                    }
-
-                                    public Object evaluate(final FunctionExpressionName name, final List<Object> parameters) {
-                                        Objects.requireNonNull(name, "name");
-                                        Objects.requireNonNull(parameters, "parameters");
-
-                                        return this.function(name).apply(parameters, this);
-                                    }
-                                }
-                        )
-        );
-    }
-
     // accept..........................................................................................................
 
     @Test
@@ -341,8 +236,6 @@ public final class FunctionExpressionTest extends VariableExpressionTestCase<Fun
                     @Override
                     public Object apply(final List<Object> parameters,
                                         final ExpressionFunctionContext context) {
-                        checkEquals(Lists.of("child-111", "child-222", "child-333"), parameters, "parameter values");
-
                         return functionValue;
                     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/399
- FunctionExpression.executeFunction which performs requiresEvaluatedParameters & resolvesReferences should be moved to ExpressionEvaluationContext.evaluate

- Closes https://github.com/mP1/walkingkooka-tree/issues/400
- BasicExpressionEvaluationContext should accept an enum to handle how references are resolved