### PR TITLE
ExpressionFunctionContext.reference pulled from ExpressionEvaluationC…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -38,17 +38,14 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
      */
     static BasicExpressionEvaluationContext with(final ExpressionNumberKind expressionNumberKind,
                                                  final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                                 final Function<ExpressionReference, Optional<Expression>> references,
                                                  final ExpressionFunctionContext functionContext) {
         Objects.requireNonNull(expressionNumberKind, "expressionNumberKind");
         Objects.requireNonNull(functions, "functions");
-        Objects.requireNonNull(references, "references");
         Objects.requireNonNull(functionContext, "functionContext");
 
         return new BasicExpressionEvaluationContext(
                 expressionNumberKind,
                 functions,
-                references,
                 functionContext
         );
     }
@@ -58,12 +55,10 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
      */
     private BasicExpressionEvaluationContext(final ExpressionNumberKind expressionNumberKind,
                                              final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                             final Function<ExpressionReference, Optional<Expression>> references,
                                              final ExpressionFunctionContext functionContext) {
         super();
         this.expressionNumberKind = expressionNumberKind;
         this.functions = functions;
-        this.references = references;
         this.functionContext = functionContext;
     }
 
@@ -129,15 +124,9 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
-        final Optional<Expression> node = this.references.apply(reference);
-        if (!node.isPresent()) {
-            throw new ExpressionEvaluationReferenceException("Missing reference: " + reference);
-        }
-        return node;
+    public Optional<Object> reference(final ExpressionReference reference) {
+        return this.functionContext.reference(reference);
     }
-
-    private final Function<ExpressionReference, Optional<Expression>> references;
 
     @Override
     public boolean canConvert(final Object value,
@@ -153,6 +142,6 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
 
     @Override
     public String toString() {
-        return this.functions + " " + this.references + " " + this.functionContext;
+        return this.functions + " " + this.functionContext;
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -94,21 +94,20 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
+    public Optional<Object> reference(final ExpressionReference reference) {
         final Set<ExpressionReference> cycles = this.cycles;
 
         this.cycleCheck(reference, cycles);
 
         try {
             cycles.add(reference);
-            final Expression result = this.context.referenceOrFail(reference);
+            final Object value = this.context.referenceOrFail(reference);
 
-            if (result.isReference()) {
-                final ReferenceExpression referenceNode = result.cast();
-                this.cycleCheck(referenceNode.value(), cycles);
+            if (value instanceof ExpressionReference) {
+                this.cycleCheck((ExpressionReference) value, cycles);
             }
 
-            return Optional.of(result);
+            return Optional.of(value);
         } finally {
             cycles.remove(reference);
         }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -21,7 +21,6 @@ import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Context that travels during any expression evaluation.
@@ -45,18 +44,5 @@ public interface ExpressionEvaluationContext extends ExpressionFunctionContext,
                 function,
                 this
         );
-    }
-
-    /**
-     * Locates the value or a {@link Expression} for the given {@link ExpressionReference}
-     */
-    Optional<Expression> reference(final ExpressionReference reference);
-
-    /**
-     * Locates the value or a {@link Expression} for the given {@link ExpressionReference} or throws a
-     * {@link ExpressionEvaluationReferenceException}.
-     */
-    default Expression referenceOrFail(final ExpressionReference reference) {
-        return this.reference(reference).orElseThrow(() -> new ExpressionEvaluationReferenceException("Unable to find " + reference));
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
@@ -21,7 +21,6 @@ import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 public final class ExpressionEvaluationContexts implements PublicStaticHelper {
@@ -31,12 +30,10 @@ public final class ExpressionEvaluationContexts implements PublicStaticHelper {
      */
     public static ExpressionEvaluationContext basic(final ExpressionNumberKind expressionNumberKind,
                                                     final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                                    final Function<ExpressionReference, Optional<Expression>> references,
                                                     final ExpressionFunctionContext functionContext) {
         return BasicExpressionEvaluationContext.with(
                 expressionNumberKind,
                 functions,
-                references,
                 functionContext
         );
     }

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -48,7 +48,7 @@ public class FakeExpressionEvaluationContext extends FakeExpressionFunctionConte
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
+    public Optional<Object> reference(final ExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/tree/expression/ReferenceExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ReferenceExpression.java
@@ -89,32 +89,32 @@ public final class ReferenceExpression extends LeafExpression<ExpressionReferenc
 
     @Override
     public boolean toBoolean(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toBoolean(context);
+        return this.toValueAndConvert(context, Boolean.class);
     }
 
     @Override
     public ExpressionNumber toExpressionNumber(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toExpressionNumber(context);
+        return this.toValueAndConvert(context, ExpressionNumber.class);
     }
 
     @Override
     public LocalDate toLocalDate(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toLocalDate(context);
+        return this.toValueAndConvert(context, LocalDate.class);
     }
 
     @Override
     public LocalDateTime toLocalDateTime(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toLocalDateTime(context);
+        return this.toValueAndConvert(context, LocalDateTime.class);
     }
 
     @Override
     public LocalTime toLocalTime(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toLocalTime(context);
+        return this.toValueAndConvert(context, LocalTime.class);
     }
 
     @Override
     public String toString(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toString(context);
+        return this.toValueAndConvert(context, String.class);
     }
 
     @Override
@@ -125,11 +125,15 @@ public final class ReferenceExpression extends LeafExpression<ExpressionReferenc
 
     @Override
     public Object toValue(final ExpressionEvaluationContext context) {
-        return this.toExpression(context).toValue(context);
+        return context.referenceOrFail(this.value);
     }
 
-    private Expression toExpression(final ExpressionEvaluationContext context) {
-        return context.referenceOrFail(this.value);
+    private <T> T toValueAndConvert(final ExpressionEvaluationContext context,
+                                    final Class<T> type) {
+        return context.convertOrFail(
+                context.referenceOrFail(this.value),
+                type
+        );
     }
 
     // Object ....................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContext.java
@@ -36,7 +36,6 @@ package walkingkooka.tree.expression.function;
 
 import walkingkooka.Either;
 import walkingkooka.convert.ConverterContext;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
@@ -58,7 +57,7 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
      */
     static BasicExpressionFunctionContext with(final ExpressionNumberKind expressionNumberKind,
                                                final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                               final Function<ExpressionReference, Optional<Expression>> references,
+                                               final Function<ExpressionReference, Optional<Object>> references,
                                                final ConverterContext converterContext) {
         Objects.requireNonNull(expressionNumberKind, "expressionNumberKind");
         Objects.requireNonNull(functions, "functions");
@@ -78,7 +77,7 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
      */
     private BasicExpressionFunctionContext(final ExpressionNumberKind expressionNumberKind,
                                            final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                           final Function<ExpressionReference, Optional<Expression>> references,
+                                           final Function<ExpressionReference, Optional<Object>> references,
                                            final ConverterContext converterContext) {
         super();
         this.expressionNumberKind = expressionNumberKind;
@@ -133,7 +132,12 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
                 .apply(parameters, this);
     }
 
-    private final Function<ExpressionReference, Optional<Expression>> references;
+    @Override
+    public Optional<Object> reference(final ExpressionReference reference) {
+        return this.references.apply(reference);
+    }
+
+    private final Function<ExpressionReference, Optional<Object>> references;
 
     @Override
     public boolean canConvert(final Object value,

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
@@ -23,10 +23,14 @@ import walkingkooka.convert.CanConvert;
 import walkingkooka.datetime.YearContext;
 import walkingkooka.locale.HasLocale;
 import walkingkooka.math.HasMathContext;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationReferenceException;
 import walkingkooka.tree.expression.ExpressionNumberContext;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Context that accompanies a {@link ExpressionFunction}.
@@ -52,4 +56,17 @@ public interface ExpressionFunctionContext extends Context,
      * Locates a function with the given name and then executes it with the provided parameter values.
      */
     Object evaluate(final FunctionExpressionName name, final List<Object> parameters);
+
+    /**
+     * Locates the value or a {@link Expression} for the given {@link ExpressionReference}
+     */
+    Optional<Object> reference(final ExpressionReference reference);
+
+    /**
+     * Locates the value for the given {@link ExpressionReference} or throws a
+     * {@link ExpressionEvaluationReferenceException}.
+     */
+    default Object referenceOrFail(final ExpressionReference reference) {
+        return this.reference(reference).orElseThrow(() -> new ExpressionEvaluationReferenceException("Unable to find " + reference));
+    }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
@@ -19,7 +19,6 @@ package walkingkooka.tree.expression.function;
 
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.reflect.PublicStaticHelper;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
@@ -34,7 +33,7 @@ public final class ExpressionFunctionContexts implements PublicStaticHelper {
      */
     public static ExpressionFunctionContext basic(final ExpressionNumberKind expressionNumberKind,
                                                   final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
-                                                  final Function<ExpressionReference, Optional<Expression>> references,
+                                                  final Function<ExpressionReference, Optional<Object>> references,
                                                   final ConverterContext converterContext) {
         return BasicExpressionFunctionContext.with(
                 expressionNumberKind,

--- a/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/FakeExpressionFunctionContext.java
@@ -19,12 +19,14 @@ package walkingkooka.tree.expression.function;
 
 import walkingkooka.convert.FakeConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 
 import java.math.MathContext;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 
 public class FakeExpressionFunctionContext extends FakeConverterContext implements ExpressionFunctionContext {
 
@@ -57,6 +59,11 @@ public class FakeExpressionFunctionContext extends FakeConverterContext implemen
 
     @Override
     public MathContext mathContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Object> reference(final ExpressionReference reference) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextReferenceFunction.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextReferenceFunction.java
@@ -19,7 +19,6 @@ package walkingkooka.tree.select;
 
 import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.Optional;
@@ -31,7 +30,7 @@ import java.util.function.Function;
 final class BasicNodeSelectorExpressionEvaluationContextReferenceFunction<N extends Node<N, NAME, ANAME, AVALUE>,
         NAME extends Name,
         ANAME extends Name,
-        AVALUE> implements Function<ExpressionReference, Optional<Expression>> {
+        AVALUE> implements Function<ExpressionReference, Optional<Object>> {
 
     static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
@@ -47,7 +46,7 @@ final class BasicNodeSelectorExpressionEvaluationContextReferenceFunction<N exte
     }
 
     @Override
-    public Optional<Expression> apply(final ExpressionReference reference) {
+    public Optional<Object> apply(final ExpressionReference reference) {
         return context.reference(reference);
     }
 

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorExpressionEvaluationContexts.java
@@ -19,7 +19,6 @@ package walkingkooka.tree.select;
 import walkingkooka.naming.Name;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionReference;
 
@@ -38,7 +37,7 @@ public final class NodeSelectorExpressionEvaluationContexts implements PublicSta
             NAME extends Name,
             ANAME extends Name,
             AVALUE> NodeSelectorExpressionEvaluationContext<N, NAME, ANAME, AVALUE> basic(final N node,
-                                                                                          final Function<Function<ExpressionReference, Optional<Expression>>, ExpressionEvaluationContext> context) {
+                                                                                          final Function<Function<ExpressionReference, Optional<Object>>, ExpressionEvaluationContext> context) {
         return BasicNodeSelectorExpressionEvaluationContext.with(node, context);
     }
 

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -50,6 +50,8 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     private final static ExpressionReference REFERENCE = new ExpressionReference() {
     };
 
+    private final static Object REFERENCE_VALUE = "expression node 123";
+
     @Test
     public void testWithNullExpressionNumberKindFails() {
         assertThrows(
@@ -57,7 +59,6 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                 () -> BasicExpressionEvaluationContext.with(
                         null,
                         this.functions(),
-                        this.references(),
                         this.functionContext()
                 )
         );
@@ -69,20 +70,6 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                 NullPointerException.class,
                 () -> BasicExpressionEvaluationContext.with(
                         KIND,
-                        null,
-                        this.references(),
-                        this.functionContext()
-                )
-        );
-    }
-
-    @Test
-    public void testWithNullReferencesFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> BasicExpressionEvaluationContext.with(
-                        KIND,
-                        this.functions(),
                         null,
                         this.functionContext()
                 )
@@ -96,7 +83,6 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                 () -> BasicExpressionEvaluationContext.with(
                         KIND,
                         this.functions(),
-                        this.references(),
                         null
                 )
         );
@@ -155,7 +141,11 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
 
     @Test
     public void testReferences() {
-        this.checkEquals(Optional.of(this.expression()), this.createContext().reference(REFERENCE));
+        this.checkEquals(
+                Optional.of(REFERENCE_VALUE),
+                this.createContext()
+                        .reference(REFERENCE)
+        );
     }
 
     @Test
@@ -166,17 +156,15 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     @Test
     public void testToString() {
         final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions = this.functions();
-        final Function<ExpressionReference, Optional<Expression>> references = this.references();
         final ExpressionFunctionContext functionContext = this.functionContext();
 
         this.toStringAndCheck(
                 BasicExpressionEvaluationContext.with(
                         KIND,
                         functions,
-                        references,
                         functionContext
                 ),
-                functions + " " + references + " " + functionContext
+                functions + " " + functionContext
         );
     }
 
@@ -189,7 +177,6 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
         return BasicExpressionEvaluationContext.with(
                 KIND,
                 this.functions(pure),
-                this.references(),
                 this.functionContext()
         );
     }
@@ -236,18 +223,6 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
         return "function-value-234";
     }
 
-    private Function<ExpressionReference, Optional<Expression>> references() {
-        return (r -> {
-            Objects.requireNonNull(r, "references");
-            this.checkEquals(REFERENCE, r, "reference");
-            return Optional.of(this.expression());
-        });
-    }
-
-    private Expression expression() {
-        return Expression.value("expression node 123");
-    }
-
     private ExpressionFunctionContext functionContext() {
         return ExpressionFunctionContexts.basic(
                 KIND,
@@ -255,6 +230,14 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                 this.references(),
                 this.converterContext()
         );
+    }
+
+    private Function<ExpressionReference, Optional<Object>> references() {
+        return (r -> {
+            Objects.requireNonNull(r, "references");
+            this.checkEquals(REFERENCE, r, "reference");
+            return Optional.of(REFERENCE_VALUE);
+        });
     }
 
     private ConverterContext converterContext() {

--- a/src/test/java/walkingkooka/tree/expression/ReferenceExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ReferenceExpressionTest.java
@@ -159,10 +159,10 @@ public final class ReferenceExpressionTest extends LeafExpressionTestCase<Refere
         return new FakeExpressionEvaluationContext() {
 
             @Override
-            public Optional<Expression> reference(final ExpressionReference reference) {
+            public Optional<Object> reference(final ExpressionReference reference) {
                 checkEquals(value, reference, "reference");
                 return Optional.of(
-                        Expression.value(referenceText)
+                        referenceText
                 );
             }
 

--- a/src/test/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContextTest.java
@@ -28,7 +28,6 @@ import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionPurityContext;
 import walkingkooka.tree.expression.ExpressionReference;
@@ -47,8 +46,11 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
         ToStringTesting<BasicExpressionFunctionContext> {
 
     private final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
+
     private final static ExpressionReference REFERENCE = new ExpressionReference() {
     };
+
+    private final static Object REFERENCE_VALUE = "*123*";
 
     @Test
     public void testWithNullExpressionNumberKindFails() {
@@ -110,6 +112,16 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
     }
 
     @Test
+    public void testReference() {
+        this.checkEquals(
+                Optional.of(
+                        REFERENCE_VALUE
+                ),
+                this.createContext().reference(REFERENCE)
+        );
+    }
+
+    @Test
     public void testConvert() {
         this.convertAndCheck(123.0, Long.class, 123L);
     }
@@ -117,7 +129,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
     @Test
     public void testToString() {
         final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions = this.functions();
-        final Function<ExpressionReference, Optional<Expression>> references = this.references();
+        final Function<ExpressionReference, Optional<Object>> references = this.references();
         final ConverterContext converterContext = this.converterContext();
 
         this.toStringAndCheck(
@@ -187,16 +199,14 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
         return "function-value-234";
     }
 
-    private Function<ExpressionReference, Optional<Expression>> references() {
+    private Function<ExpressionReference, Optional<Object>> references() {
         return (r -> {
             Objects.requireNonNull(r, "references");
             this.checkEquals(REFERENCE, r, "reference");
-            return Optional.of(this.expression());
+            return Optional.of(
+                    REFERENCE_VALUE
+            );
         });
-    }
-
-    private Expression expression() {
-        return Expression.value("expression node 123");
     }
 
     private ConverterContext converterContext() {

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
@@ -181,7 +181,6 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
                 return ExpressionEvaluationContexts.basic(
                         ExpressionNumberKind.DEFAULT,
                         this.functions(),
-                        this.references(),
                         this.functionContext()
                 );
             }
@@ -192,10 +191,6 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
                 };
             }
 
-            private Function<ExpressionReference, Optional<Expression>> references() {
-                return (r) -> Optional.empty();
-            }
-
             private ExpressionFunctionContext functionContext() {
                 return ExpressionFunctionContexts.basic(
                         KIND,
@@ -203,6 +198,10 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
                         this.references(),
                         this.converterContext()
                 );
+            }
+
+            private Function<ExpressionReference, Optional<Object>> references() {
+                return (r) -> Optional.empty();
             }
 
             private ExpressionNumberConverterContext converterContext() {

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
@@ -111,7 +111,7 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements N
                 .setAttributes(Maps.of(Names.string(attribute), value));
 
         this.checkEquals(
-                Expression.value(value),
+                value,
                 this.createContext(node)
                         .referenceOrFail(NodeSelectorAttributeName.with(attribute))
         );
@@ -127,7 +127,6 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements N
                 (r) -> ExpressionEvaluationContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
-                        r,
                         this.functionContext()
                 ));
     }
@@ -148,7 +147,7 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements N
         );
     }
 
-    private Function<ExpressionReference, Optional<Expression>> references() {
+    private Function<ExpressionReference, Optional<Object>> references() {
         return (r -> {
             throw new UnsupportedOperationException();
         });

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorContext2ExpressionNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorContext2ExpressionNodeSelectorTest.java
@@ -30,12 +30,9 @@ import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContexts;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
-import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.function.ExpressionFunctionContexts;
 
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -119,12 +116,6 @@ public final class NodeSelectorContext2ExpressionNodeSelectorTest extends NodeSe
                                         EXPRESSION_NUMBER_KIND,
                                         (f) -> {
                                             throw new UnsupportedOperationException();
-                                        },
-                                        new Function<>() {
-                                            @Override
-                                            public Optional<Expression> apply(final ExpressionReference reference) {
-                                                throw new UnsupportedOperationException();
-                                            }
                                         },
                                         ExpressionFunctionContexts.fake()
                                 )

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1837,7 +1837,6 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                                 (r) -> ExpressionEvaluationContexts.basic(
                                         EXPRESSION_NUMBER_KIND,
                                         Cast.to(this.functions()),
-                                        r,
                                         this.functionContext()
                                 )
                         );
@@ -1925,7 +1924,7 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                         );
                     }
 
-                    private Function<ExpressionReference, Optional<Expression>> references() {
+                    private Function<ExpressionReference, Optional<Object>> references() {
                         return (r -> {
                             throw new UnsupportedOperationException();
                         });

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
@@ -447,7 +447,6 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
                 (r) -> ExpressionEvaluationContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
-                        r,
                         this.functionContext()
                 )
         );
@@ -479,7 +478,7 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
         );
     }
 
-    private Function<ExpressionReference, Optional<Expression>> references() {
+    private Function<ExpressionReference, Optional<Object>> references() {
         return (r -> {
             throw new UnsupportedOperationException();
         });


### PR DESCRIPTION
…ontext

- reference now returns Optional<Object> and not Optional<Expression>
- Update ExpressionEvaluationContext impl to call wrapped ExpressionFunctionContexts.reference

- Closes https://github.com/mP1/walkingkooka-tree/issues/408
- Pull ExpressionEvaluationContext.reference to ExpressionFunctionContex