### PR TITLE
ExpressionFunctionContext.referenceNotFound

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceException.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceException.java
@@ -20,7 +20,7 @@ package walkingkooka.tree.expression;
 /**
  * This exception is thrown whenever a reference lookup fails.
  */
-public class ExpressionEvaluationReferenceException extends ExpressionException {
+public class ExpressionEvaluationReferenceException extends ExpressionEvaluationException {
 
     private static final long serialVersionUID = 1;
 

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
@@ -24,6 +24,7 @@ import walkingkooka.datetime.YearContext;
 import walkingkooka.locale.HasLocale;
 import walkingkooka.math.HasMathContext;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.expression.ExpressionEvaluationReferenceException;
 import walkingkooka.tree.expression.ExpressionNumberContext;
 import walkingkooka.tree.expression.ExpressionReference;
@@ -67,6 +68,14 @@ public interface ExpressionFunctionContext extends Context,
      * {@link ExpressionEvaluationReferenceException}.
      */
     default Object referenceOrFail(final ExpressionReference reference) {
-        return this.reference(reference).orElseThrow(() -> new ExpressionEvaluationReferenceException("Unable to find " + reference));
+        return this.reference(reference)
+                .orElseThrow(() -> this.referenceNotFound(reference));
+    }
+
+    /**
+     * Returns a {@link ExpressionEvaluationException} that captures the given {@link ExpressionReference} was not found.
+     */
+    default ExpressionEvaluationException referenceNotFound(final ExpressionReference reference) {
+        return new ExpressionEvaluationReferenceException("Unable to find " + reference);
     }
 }


### PR DESCRIPTION
- ExpressionEvaluationReferenceException now extends ExpressionEvaluationException previously ExpressionException