### PR TITLE
BasicExpressionFunctionContext-referenceNotFound factory function

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContext.java
@@ -36,6 +36,7 @@ package walkingkooka.tree.expression.function;
 
 import walkingkooka.Either;
 import walkingkooka.convert.ConverterContext;
+import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
@@ -58,16 +59,19 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
     static BasicExpressionFunctionContext with(final ExpressionNumberKind expressionNumberKind,
                                                final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
                                                final Function<ExpressionReference, Optional<Object>> references,
+                                               final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                                final ConverterContext converterContext) {
         Objects.requireNonNull(expressionNumberKind, "expressionNumberKind");
         Objects.requireNonNull(functions, "functions");
         Objects.requireNonNull(references, "references");
+        Objects.requireNonNull(referenceNotFound, "referenceNotFound");
         Objects.requireNonNull(converterContext, "converterContext");
 
         return new BasicExpressionFunctionContext(
                 expressionNumberKind,
                 functions,
                 references,
+                referenceNotFound,
                 converterContext
         );
     }
@@ -78,11 +82,13 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
     private BasicExpressionFunctionContext(final ExpressionNumberKind expressionNumberKind,
                                            final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
                                            final Function<ExpressionReference, Optional<Object>> references,
+                                           final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                            final ConverterContext converterContext) {
         super();
         this.expressionNumberKind = expressionNumberKind;
         this.functions = functions;
         this.references = references;
+        this.referenceNotFound = referenceNotFound;
         this.converterContext = converterContext;
     }
 
@@ -140,6 +146,13 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
     private final Function<ExpressionReference, Optional<Object>> references;
 
     @Override
+    public ExpressionEvaluationException referenceNotFound(final ExpressionReference reference) {
+        return this.referenceNotFound(reference);
+    }
+
+    private final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound;
+
+    @Override
     public boolean canConvert(final Object value,
                               final Class<?> type) {
         return this.converterContext.canConvert(value, type);
@@ -155,6 +168,6 @@ final class BasicExpressionFunctionContext implements ExpressionFunctionContext 
 
     @Override
     public String toString() {
-        return this.functions + " " + this.references + " " + this.converterContext;
+        return this.functions + " " + this.references + " " + this.referenceNotFound + " " + this.converterContext;
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
@@ -19,6 +19,8 @@ package walkingkooka.tree.expression.function;
 
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.reflect.PublicStaticHelper;
+import walkingkooka.tree.expression.ExpressionEvaluationException;
+import walkingkooka.tree.expression.ExpressionEvaluationReferenceException;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
@@ -34,11 +36,13 @@ public final class ExpressionFunctionContexts implements PublicStaticHelper {
     public static ExpressionFunctionContext basic(final ExpressionNumberKind expressionNumberKind,
                                                   final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
                                                   final Function<ExpressionReference, Optional<Object>> references,
+                                                  final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                                   final ConverterContext converterContext) {
         return BasicExpressionFunctionContext.with(
                 expressionNumberKind,
                 functions,
                 references,
+                referenceNotFound,
                 converterContext
         );
     }
@@ -48,6 +52,16 @@ public final class ExpressionFunctionContexts implements PublicStaticHelper {
      */
     public static ExpressionFunctionContext fake() {
         return new FakeExpressionFunctionContext();
+    }
+
+    /**
+     * A function that creates a {@link ExpressionEvaluationReferenceException}.
+     */
+    public static Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound() {
+        return (r) -> new ExpressionEvaluationReferenceException(
+                "Reference not found",
+                r
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -228,6 +228,7 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                 KIND,
                 this.functions(),
                 this.references(),
+                ExpressionFunctionContexts.referenceNotFound(),
                 this.converterContext()
         );
     }

--- a/src/test/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/BasicExpressionFunctionContextTest.java
@@ -28,6 +28,7 @@ import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionPurityContext;
 import walkingkooka.tree.expression.ExpressionReference;
@@ -60,6 +61,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                         null,
                         this.functions(),
                         this.references(),
+                        ExpressionFunctionContexts.referenceNotFound(),
                         this.converterContext()
                 )
         );
@@ -73,6 +75,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                         KIND,
                         null,
                         this.references(),
+                        ExpressionFunctionContexts.referenceNotFound(),
                         this.converterContext()
                 )
         );
@@ -85,6 +88,21 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                 () -> BasicExpressionFunctionContext.with(
                         KIND,
                         this.functions(),
+                        null,
+                        ExpressionFunctionContexts.referenceNotFound(),
+                        this.converterContext()
+                )
+        );
+    }
+
+    @Test
+    public void testWithNullReferenceNotFoundFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> BasicExpressionFunctionContext.with(
+                        KIND,
+                        this.functions(),
+                        this.references(),
                         null,
                         this.converterContext()
                 )
@@ -99,6 +117,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                         KIND,
                         this.functions(),
                         this.references(),
+                        ExpressionFunctionContexts.referenceNotFound(),
                         null
                 )
         );
@@ -130,6 +149,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
     public void testToString() {
         final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions = this.functions();
         final Function<ExpressionReference, Optional<Object>> references = this.references();
+        final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound = ExpressionFunctionContexts.referenceNotFound();
         final ConverterContext converterContext = this.converterContext();
 
         this.toStringAndCheck(
@@ -137,9 +157,10 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                         KIND,
                         functions,
                         references,
+                        referenceNotFound,
                         converterContext
                 ),
-                functions + " " + references + " " + converterContext
+                functions + " " + references + " " + referenceNotFound + " " + converterContext
         );
     }
 
@@ -153,6 +174,7 @@ public final class BasicExpressionFunctionContextTest implements ClassTesting2<B
                 KIND,
                 this.functions(pure),
                 this.references(),
+                ExpressionFunctionContexts.referenceNotFound(),
                 this.converterContext()
         );
     }

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
@@ -196,6 +196,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
                         KIND,
                         this.functions(),
                         this.references(),
+                        ExpressionFunctionContexts.referenceNotFound(),
                         this.converterContext()
                 );
             }

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
@@ -143,6 +143,7 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements N
                 EXPRESSION_NUMBER_KIND,
                 this.functions(),
                 this.references(),
+                ExpressionFunctionContexts.referenceNotFound(),
                 this.converterContext()
         );
     }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1920,6 +1920,7 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                                 EXPRESSION_NUMBER_KIND,
                                 Cast.to(this.functions()),
                                 this.references(),
+                                ExpressionFunctionContexts.referenceNotFound(),
                                 this.converterContext()
                         );
                     }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
@@ -474,6 +474,7 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
                 EXPRESSION_NUMBER_KIND,
                 this.functions(),
                 this.references(),
+                ExpressionFunctionContexts.referenceNotFound(),
                 this.converterContext()
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/411
- BasicExpressionFunctionContext should take a function which returns throwable when reference not found