### PR TITLE
ExpressionFunctionContexts.referenceNotFound include reference in mes…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContext.java
@@ -76,9 +76,6 @@ public interface ExpressionFunctionContext extends Context,
      * Returns a {@link ExpressionEvaluationException} that captures the given {@link ExpressionReference} was not found.
      */
     default ExpressionEvaluationException referenceNotFound(final ExpressionReference reference) {
-        return new ExpressionEvaluationReferenceException(
-                "Unable to find " + reference,
-                reference
-        );
+        return ExpressionFunctionContexts.referenceNotFound().apply(reference);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionContexts.java
@@ -59,7 +59,7 @@ public final class ExpressionFunctionContexts implements PublicStaticHelper {
      */
     public static Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound() {
         return (r) -> new ExpressionEvaluationReferenceException(
-                "Reference not found",
+                "Reference not found: " + r,
                 r
         );
     }

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionContextsTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionContextsTest.java
@@ -17,12 +17,41 @@
 
 package walkingkooka.tree.expression.function;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.PublicStaticHelperTesting;
+import walkingkooka.tree.expression.ExpressionEvaluationReferenceException;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import java.lang.reflect.Method;
 
 public class ExpressionFunctionContextsTest implements PublicStaticHelperTesting<ExpressionFunctionContexts> {
+
+    @Test
+    public void testReferenceNotFound() {
+        final ExpressionReference reference = new ExpressionReference() {
+            @Override
+            public String toString() {
+                return "Reference123";
+            }
+        };
+
+        final ExpressionEvaluationReferenceException thrown = (ExpressionEvaluationReferenceException) ExpressionFunctionContexts.referenceNotFound()
+                .apply(reference);
+
+        this.checkEquals(
+                reference,
+                thrown.expressionReference(),
+                () -> reference.toString()
+        );
+
+
+        this.checkEquals(
+                "Reference not found: Reference123",
+                thrown.getMessage(),
+                () -> reference.toString()
+        );
+    }
 
     @Override
     public Class<ExpressionFunctionContexts> type() {


### PR DESCRIPTION
…sage

- ExpressionFunctionContext.referenceNotFound() calls ExpressionFunctionContexts.referenceNotFound()