### PR TITLE
ExpressionNumber divide by zero throws ExpressionEvaluationException …

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumber.java
@@ -182,7 +182,11 @@ public abstract class ExpressionNumber extends Number implements Comparable<Expr
     public final ExpressionNumber divide(final ExpressionNumber value, final ExpressionNumberContext context) {
         check(value);
 
-        return this.divide0(value, context);
+        try {
+            return this.divide0(value, context);
+        } catch (final ArithmeticException cause) {
+            throw new ExpressionEvaluationException("Division by zero", cause);
+        }
     }
 
     abstract ExpressionNumber divide0(final ExpressionNumber value, final ExpressionNumberContext context);

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberBigDecimal.java
@@ -134,11 +134,11 @@ final class ExpressionNumberBigDecimal extends ExpressionNumber {
 
     @Override
     ExpressionNumber divide0(final ExpressionNumber value, final ExpressionNumberContext context) {
-        try {
-            return this.setValue(this.value.divide(value.bigDecimal(), context.mathContext()));
-        } catch (final ArithmeticException cause) {
-            throw new ExpressionEvaluationException("Division by zero", cause);
-        }
+        return this.setValue(
+                this.value.divide(value.bigDecimal(),
+                        context.mathContext()
+                )
+        );
     }
 
     // max..............................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberDouble.java
@@ -124,12 +124,14 @@ final class ExpressionNumberDouble extends ExpressionNumber {
     // divide..............................................................................................................
 
     @Override
-    ExpressionNumber divide0(final ExpressionNumber value, final ExpressionNumberContext context) {
-        final double doubleValue = value.doubleValue();
-        if (doubleValue == 0) {
-            throw new ExpressionEvaluationException("Division by zero");
+    ExpressionNumber divide0(final ExpressionNumber value,
+                             final ExpressionNumberContext context) {
+        final double result = this.value / value.doubleValue();
+
+        if (Double.isInfinite(result)) {
+            throw new ArithmeticException("Division by zero");
         }
-        return this.setValue(this.value / doubleValue);
+        return this.setValue(result);
     }
 
     // max..............................................................................................................

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberTestCase.java
@@ -317,8 +317,20 @@ public abstract class ExpressionNumberTestCase<N extends ExpressionNumber> imple
         final int value = 1;
 
         final N number = this.create(value);
-        final ExpressionEvaluationException thrown = assertThrows(ExpressionEvaluationException.class, () -> number.divide(this.create(0), CONTEXT));
-        this.checkEquals("Division by zero", thrown.getMessage(), "message");
+        final ExpressionEvaluationException thrown = assertThrows(
+                ExpressionEvaluationException.class,
+                () -> number.divide(this.create(0), CONTEXT)
+        );
+        this.checkEquals(
+                "Division by zero",
+                thrown.getMessage(),
+                "message"
+        );
+        this.checkEquals(
+                ArithmeticException.class,
+                thrown.getCause().getClass(),
+                () -> "cause class"
+        );
     }
 
     @Test


### PR DESCRIPTION
…wrapping ArithmeticException

- Closes https://github.com/mP1/walkingkooka-tree/issues/423
- DivideExpression divide by zero should throw ArithmeticException not ExpressionEvaluationException