### PR TITLE
CustomNameExpressionFunctionTest.testSetNameDifferent fixed check

### DIFF
--- a/src/test/java/walkingkooka/tree/expression/function/CustomNameExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/CustomNameExpressionFunctionTest.java
@@ -64,7 +64,7 @@ public final class CustomNameExpressionFunctionTest extends ExpressionFunctionTe
 
         assertNotSame(function, differentFunction);
         assertSame(different, differentFunction.name());
-        assertNotSame(function, function.name());
+        this.checkEquals(NAME, function.name());
     }
 
     // toString.........................................................................................................


### PR DESCRIPTION
- assertion wasnt failing but was wrong.