### PR TITLE
ExpressionFunctionKind.EVALUATE_PARAMETERS was REQUIRES-EVALUATED_PAR…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -37,7 +37,7 @@ public interface ExpressionEvaluationContext extends ExpressionFunctionContext,
     /**
      * Wraps the {@link List} of parameters values and performs several actions lazily for each parameter.
      * <ul>
-     * <li>Resolve {@link Expression} if {@link walkingkooka.tree.expression.function.ExpressionFunctionKind#EVALUATED_PARAMETERS}</li>
+     * <li>Resolve {@link Expression} if {@link walkingkooka.tree.expression.function.ExpressionFunctionKind#EVALUATE_PARAMETERS}</li>
      * <li>Resolve {@link ReferenceExpression} if {@link walkingkooka.tree.expression.function.ExpressionFunctionKind#RESOLVE_REFERENCES}</li>
      * <li>Convert values to the {@link ExpressionFunctionParameter#type()}</li>
      * </ul>

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersList.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersList.java
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * Wraps the {@link List} of parameters values and performs several actions lazily for each parameter.
  * <ul>
- * <li>Evaluate {@link Expression} if {@link ExpressionFunctionKind#EVALUATED_PARAMETERS}</li>
+ * <li>Evaluate {@link Expression} if {@link ExpressionFunctionKind#EVALUATE_PARAMETERS}</li>
  * <li>Resolve {@link ReferenceExpression} if {@link ExpressionFunctionKind#RESOLVE_REFERENCES}</li>
  * <li>Convert values to the {@link ExpressionFunctionParameter#type()}</li>
  * </ul>
@@ -66,7 +66,7 @@ abstract class ExpressionEvaluationContextPrepareParametersList extends Abstract
         Object result = parameterValue;
 
         if (result instanceof Expression) {
-            if (kinds.contains(ExpressionFunctionKind.EVALUATED_PARAMETERS)) {
+            if (kinds.contains(ExpressionFunctionKind.EVALUATE_PARAMETERS)) {
                 result = toReferenceOrValue(result, context);
             }
         }
@@ -74,7 +74,7 @@ abstract class ExpressionEvaluationContextPrepareParametersList extends Abstract
             if (kinds.contains(ExpressionFunctionKind.RESOLVE_REFERENCES)) {
                 result = context.referenceOrFail((ExpressionReference) result);
 
-                if (result instanceof Expression && kinds.contains(ExpressionFunctionKind.EVALUATED_PARAMETERS)) {
+                if (result instanceof Expression && kinds.contains(ExpressionFunctionKind.EVALUATE_PARAMETERS)) {
                     result = toReferenceOrValue(result, context);
                 }
             }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattened.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattened.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * A lazy {@link List} of the original parameter values, performing the following if they are enabled for this function.
  * <ul>
- * <li>Evaluate {@link Expression} if {@link ExpressionFunctionKind#EVALUATED_PARAMETERS}</li>
+ * <li>Evaluate {@link Expression} if {@link ExpressionFunctionKind#EVALUATE_PARAMETERS}</li>
  * <li>Resolve {@link ReferenceExpression} if {@link ExpressionFunctionKind#RESOLVE_REFERENCES}</li>
  * <li>Convert values to the {@link ExpressionFunctionParameter#type()}</li>
  * </ul>

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionKind.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionKind.java
@@ -32,7 +32,7 @@ public enum ExpressionFunctionKind {
      * cases all functions will return true, but for cases such as Excels isError it may be desired to catch any thrown
      * exceptions and substitute an error object of some kind.
      */
-    EVALUATED_PARAMETERS,
+    EVALUATE_PARAMETERS,
 
     /**
      * Flatten expands any lists.

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
@@ -94,7 +94,7 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionFunct
     }
 
     private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-            ExpressionFunctionKind.EVALUATED_PARAMETERS,
+            ExpressionFunctionKind.EVALUATE_PARAMETERS,
             ExpressionFunctionKind.RESOLVE_REFERENCES
     );
 

--- a/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeExpressionFunction.java
@@ -92,7 +92,7 @@ final class NodeExpressionFunction<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-            ExpressionFunctionKind.EVALUATED_PARAMETERS,
+            ExpressionFunctionKind.EVALUATE_PARAMETERS,
             ExpressionFunctionKind.RESOLVE_REFERENCES
     );
 

--- a/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/NodeNameExpressionFunction.java
@@ -88,7 +88,7 @@ final class NodeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     }
 
     private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-            ExpressionFunctionKind.EVALUATED_PARAMETERS,
+            ExpressionFunctionKind.EVALUATE_PARAMETERS,
             ExpressionFunctionKind.RESOLVE_REFERENCES
     );
 

--- a/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/TypeNameExpressionFunction.java
@@ -86,7 +86,7 @@ final class TypeNameExpressionFunction<C extends ExpressionFunctionContext> impl
     }
 
     private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-            ExpressionFunctionKind.EVALUATED_PARAMETERS,
+            ExpressionFunctionKind.EVALUATE_PARAMETERS,
             ExpressionFunctionKind.RESOLVE_REFERENCES
     );
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListFlattenedTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListFlattenedTest.java
@@ -109,7 +109,7 @@ public final class ExpressionEvaluationContextPrepareParametersListFlattenedTest
                         parameters,
                         function(
                                 Lists.of(VARIABLE),
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES,
                                 ExpressionFunctionKind.FLATTEN
                         ),
@@ -138,7 +138,7 @@ public final class ExpressionEvaluationContextPrepareParametersListFlattenedTest
                         ),
                         function(
                                 Lists.of(VARIABLE),
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES,
                                 ExpressionFunctionKind.FLATTEN
                         ),
@@ -161,7 +161,7 @@ public final class ExpressionEvaluationContextPrepareParametersListFlattenedTest
                         ),
                         function(
                                 Lists.of(VARIABLE),
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES,
                                 ExpressionFunctionKind.FLATTEN
                         ),

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattenedTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattenedTest.java
@@ -105,7 +105,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
         final ExpressionEvaluationContextPrepareParametersListNonFlattened list = Cast.to(
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
-                        this.function(ExpressionFunctionKind.EVALUATED_PARAMETERS),
+                        this.function(ExpressionFunctionKind.EVALUATE_PARAMETERS),
                         CONTEXT
                 )
         );
@@ -127,7 +127,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
         final ExpressionEvaluationContextPrepareParametersListNonFlattened list = Cast.to(
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
-                        this.function(ExpressionFunctionKind.EVALUATED_PARAMETERS),
+                        this.function(ExpressionFunctionKind.EVALUATE_PARAMETERS),
                         CONTEXT
                 )
         );
@@ -149,7 +149,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
         final ExpressionEvaluationContextPrepareParametersListNonFlattened list = Cast.to(
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
-                        this.function(ExpressionFunctionKind.EVALUATED_PARAMETERS),
+                        this.function(ExpressionFunctionKind.EVALUATE_PARAMETERS),
                         CONTEXT
                 )
         );
@@ -171,7 +171,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
         final ExpressionEvaluationContextPrepareParametersListNonFlattened list = Cast.to(
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
-                        this.function(ExpressionFunctionKind.EVALUATED_PARAMETERS),
+                        this.function(ExpressionFunctionKind.EVALUATE_PARAMETERS),
                         CONTEXT
                 )
         );
@@ -279,7 +279,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
                         this.function(
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES
                         ),
                         new FakeExpressionEvaluationContext() {
@@ -318,7 +318,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                 ExpressionEvaluationContextPrepareParametersList.with(
                         parameters,
                         this.function(
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES
                         ),
                         new FakeExpressionEvaluationContext() {
@@ -410,7 +410,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                         ),
                         function(
                                 Lists.of(VARIABLE),
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES
                         ),
                         CONTEXT_PARSE_INT
@@ -432,7 +432,7 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                         ),
                         function(
                                 Lists.of(VARIABLE),
-                                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                                 ExpressionFunctionKind.RESOLVE_REFERENCES
                         ),
                         new FakeExpressionEvaluationContext() {

--- a/src/test/java/walkingkooka/tree/expression/FunctionExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/FunctionExpressionTest.java
@@ -249,7 +249,7 @@ public final class FunctionExpressionTest extends VariableExpressionTestCase<Fun
                     }
 
                     private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-                            ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                            ExpressionFunctionKind.EVALUATE_PARAMETERS,
                             ExpressionFunctionKind.RESOLVE_REFERENCES
                     );
                 };

--- a/src/test/java/walkingkooka/tree/expression/function/CustomKindsExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/CustomKindsExpressionFunctionTest.java
@@ -64,7 +64,7 @@ public final class CustomKindsExpressionFunctionTest extends ExpressionFunctionT
         final CustomKindsExpressionFunction<String, ExpressionFunctionContext> function = this.createBiFunction();
 
         final Set<ExpressionFunctionKind> different = Sets.of(
-                ExpressionFunctionKind.EVALUATED_PARAMETERS
+                ExpressionFunctionKind.EVALUATE_PARAMETERS
         );
         final ExpressionFunction<String, ExpressionFunctionContext> differentFunction = function.setKinds(different);
 

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -2032,7 +2032,7 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
         }
 
         private final Set<ExpressionFunctionKind> KINDS = EnumSet.of(
-                ExpressionFunctionKind.EVALUATED_PARAMETERS,
+                ExpressionFunctionKind.EVALUATE_PARAMETERS,
                 ExpressionFunctionKind.RESOLVE_REFERENCES
         );
     }


### PR DESCRIPTION
…AMETERS

- Closes https://github.com/mP1/walkingkooka-tree/issues/502
- ExpressionFunction.EVALUATE_PARAMETERS rename from REQUIRES_EVALUATED_PARAMETERS