### PR TITLE
ExpressionNumberKind.parseWithBase decimal fix

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberKind.java
@@ -238,11 +238,24 @@ public enum ExpressionNumberKind {
         }
 
         ExpressionNumber value = this.zero();
+        boolean afterDecimal = false;
+
         for (int i = start; i < length; i++) {
             final char c = text.charAt(i);
+            if (context.decimalSeparator() == c) {
+                if (afterDecimal) {
+                    throw new InvalidCharacterException(text, i);
+                }
+                afterDecimal = true;
+                continue;
+            }
             final int charNumericValue = Character.digit(c, base);
             if (-1 == charNumericValue) {
                 throw new InvalidCharacterException(text, i);
+            }
+
+            if (afterDecimal) {
+                continue;
             }
 
             value = value.multiply(multiplier, context)

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberKindTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberKindTest.java
@@ -456,7 +456,12 @@ public final class ExpressionNumberKindTest implements ClassTesting<ExpressionNu
                 ExpressionNumberKind.BIG_DECIMAL,
                 text,
                 10,
-                this.createContext(ExpressionNumberKind.BIG_DECIMAL, '*', '!'),
+                this.createContext(
+                        ExpressionNumberKind.BIG_DECIMAL,
+                        '*',
+                        '!',
+                        '@'
+                ),
                 ExpressionNumberKind.BIG_DECIMAL.create(123)
         );
     }
@@ -469,8 +474,49 @@ public final class ExpressionNumberKindTest implements ClassTesting<ExpressionNu
                 ExpressionNumberKind.BIG_DECIMAL,
                 text,
                 10,
-                this.createContext(ExpressionNumberKind.BIG_DECIMAL, '!', '*'),
+                this.createContext(
+                        ExpressionNumberKind.BIG_DECIMAL,
+                        '!',
+                        '*',
+                        '@'
+                ),
                 ExpressionNumberKind.BIG_DECIMAL.create(-123)
+        );
+    }
+
+    @Test
+    public void testParseWithBaseDecimal() {
+        final String text = "123@";
+
+        this.parseWithBaseAndCheck(
+                ExpressionNumberKind.BIG_DECIMAL,
+                text,
+                10,
+                this.createContext(
+                        ExpressionNumberKind.BIG_DECIMAL,
+                        '!',
+                        '*',
+                        '@'
+                ),
+                ExpressionNumberKind.BIG_DECIMAL.create(123)
+        );
+    }
+
+    @Test
+    public void testParseWithBaseDecimalsIgnored() {
+        final String text = "123@678";
+
+        this.parseWithBaseAndCheck(
+                ExpressionNumberKind.BIG_DECIMAL,
+                text,
+                10,
+                this.createContext(
+                        ExpressionNumberKind.BIG_DECIMAL,
+                        '!',
+                        '*',
+                        '@'
+                ),
+                ExpressionNumberKind.BIG_DECIMAL.create(123)
         );
     }
 
@@ -782,14 +828,22 @@ public final class ExpressionNumberKindTest implements ClassTesting<ExpressionNu
         return this.createContext(
                 kind,
                 '+',
-                '-'
+                '-',
+                '.'
         );
     }
 
     private ExpressionNumberContext createContext(final ExpressionNumberKind kind,
                                                   final char plus,
-                                                  final char minus) {
+                                                  final char minus,
+                                                  final char decimalSeparator) {
         return new FakeExpressionNumberContext() {
+
+            @Override
+            public char decimalSeparator() {
+                return decimalSeparator;
+            }
+
             @Override
             public ExpressionNumberKind expressionNumberKind() {
                 return kind;
@@ -800,11 +854,13 @@ public final class ExpressionNumberKindTest implements ClassTesting<ExpressionNu
                 return MathContext.UNLIMITED;
             }
 
-            @Override public char negativeSign() {
+            @Override
+            public char negativeSign() {
                 return minus;
             }
 
-            @Override public char positiveSign() {
+            @Override
+            public char positiveSign() {
                 return plus;
             }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/508
- ExpressionFunctionKind.parseWithBase should consume but ignore any decimals.