### PR TITLE
ExpressionEvaluationContext.isText()

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -96,6 +96,11 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
 
     private final CaseSensitivity caseSensitivity;
 
+    @Override
+    public boolean isText(final Object value) {
+        return value instanceof Character || value instanceof CharSequence;
+    }
+
     // DateTimeContext.................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/BinaryArithmeticExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/BinaryArithmeticExpression.java
@@ -39,12 +39,13 @@ abstract class BinaryArithmeticExpression extends BinaryExpression {
      * Includes dispatch logic with a special case if the left parameter is text, otherwise both values
      * are converted to {@link ExpressionNumber} and given to {@link #applyExpressionNumber(ExpressionNumber, ExpressionNumber, ExpressionEvaluationContext)}.
      */
-    @Override final Expression apply(final Object left,
-                                     final Object right,
-                                     final ExpressionEvaluationContext context) {
+    @Override //
+    final Expression apply(final Object left,
+                           final Object right,
+                           final ExpressionEvaluationContext context) {
         final Object result;
 
-        if (left instanceof Character || left instanceof String) {
+        if (context.isText(left)) {
             result = this.applyText(
                     context.convertOrFail(left, String.class),
                     context.convertOrFail(right, String.class),

--- a/src/main/java/walkingkooka/tree/expression/BinaryComparisonExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/BinaryComparisonExpression.java
@@ -36,13 +36,14 @@ abstract class BinaryComparisonExpression extends BinaryExpression {
         return this.toBoolean(context);
     }
 
-    @Override final Expression apply(final Object left,
-                                     final Object right,
-                                     final ExpressionEvaluationContext context) {
+    @Override //
+    final Expression apply(final Object left,
+                           final Object right,
+                           final ExpressionEvaluationContext context) {
         final ComparisonRelation compare = this.comparisonRelation();
 
         final Object result;
-        if (left instanceof Character || left instanceof String) {
+        if (context.isText(left)) {
             result = this.applyText(
                     compare,
                     context.convertOrFail(left, String.class),

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -247,6 +247,11 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
         return this.context.caseSensitivity();
     }
 
+    @Override
+    public boolean isText(final Object value) {
+        return this.context.isText(value);
+    }
+
     private final ExpressionEvaluationContext context;
 
     // toString.........................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -127,6 +127,12 @@ public interface ExpressionEvaluationContext extends Context,
     }
 
     /**
+     * Tests if the given value should be considered text. This might be useful to prepare a value for {@link String
+     * comparison.
+     */
+    boolean isText(final Object value);
+
+    /**
      * Controls whether equals or not equals tests are case sensitive for {@link String strings}
      */
     CaseSensitivity caseSensitivity();

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -49,6 +49,11 @@ public class FakeExpressionEvaluationContext extends FakeConverterContext implem
     }
 
     @Override
+    public boolean isText(final Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public <T> T prepareParameter(final ExpressionFunctionParameter<T> parameter,
                                   final Object value) {
         Objects.requireNonNull(parameter, "parameter");

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -280,6 +280,11 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
         return this.context.caseSensitivity();
     }
 
+    @Override
+    public boolean isText(final Object value) {
+        return this.context.isText(value);
+    }
+
     private final ExpressionEvaluationContext context;
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattenedTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListNonFlattenedTest.java
@@ -514,6 +514,11 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                             public Object handleException(final RuntimeException exception) {
                                 return "@@@" + exception.getMessage();
                             }
+
+                            @Override
+                            public boolean isText(final Object value) {
+                                return value instanceof String;
+                            }
                         }
                 )
         );
@@ -557,6 +562,11 @@ public final class ExpressionEvaluationContextPrepareParametersListNonFlattenedT
                             @Override
                             public Object handleException(final RuntimeException exception) {
                                 return "@@@" + exception.getMessage();
+                            }
+
+                            @Override
+                            public boolean isText(final Object value) {
+                                return value instanceof String;
                             }
                         }
                 )

--- a/src/test/java/walkingkooka/tree/expression/ExpressionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionTestCase.java
@@ -411,6 +411,11 @@ public abstract class ExpressionTestCase<N extends Expression> implements TreePr
             public CaseSensitivity caseSensitivity() {
                 return CaseSensitivity.SENSITIVE;
             }
+
+            @Override
+            public boolean isText(final Object value) {
+                return value instanceof String;
+            }
         };
     }
 


### PR DESCRIPTION
- Updated Arithmetic & Logical Expression evaluation replacing instanceof String etc checks.

- Closes https://github.com/mP1/walkingkooka-tree/issues/539
- ExpressionEvaluationContext.isText()