### PR TITLE
ExpressionEvaluationContext.evaluateFunction was evaluate

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -255,8 +255,8 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     }
 
     @Override
-    public Object evaluate(final FunctionExpressionName name,
-                           final List<Object> parameters) {
+    public Object evaluateFunction(final FunctionExpressionName name,
+                                   final List<Object> parameters) {
         Object result;
 
         try {

--- a/src/main/java/walkingkooka/tree/expression/CallExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/CallExpression.java
@@ -171,7 +171,7 @@ public final class CallExpression extends VariableExpression {
                                     final ExpressionEvaluationContext context) {
         final NamedFunctionExpression callable = (NamedFunctionExpression) this.callable();
 
-        return context.evaluate(
+        return context.evaluateFunction(
                 callable.value(),
                 Cast.to(parameters)
         );

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -77,8 +77,8 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
-    public Object evaluate(final FunctionExpressionName functionName, final List<Object> parameters) {
-        return this.context.evaluate(functionName, parameters);
+    public Object evaluateFunction(final FunctionExpressionName functionName, final List<Object> parameters) {
+        return this.context.evaluateFunction(functionName, parameters);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -98,7 +98,7 @@ public interface ExpressionEvaluationContext extends Context,
     /**
      * Locates a {@link ExpressionFunction} with the given {@link FunctionExpressionName} and then executes it with the provided parameter values.
      */
-    Object evaluate(final FunctionExpressionName name, final List<Object> parameters);
+    Object evaluateFunction(final FunctionExpressionName name, final List<Object> parameters);
 
     /**
      * Receives all {@link RuntimeException} thrown by a {@link ExpressionFunction} or {@link Expression}.
@@ -110,7 +110,7 @@ public interface ExpressionEvaluationContext extends Context,
      * <br>
      * This should be called whenever an {@link RuntimeException} is thrown by
      * <ul>
-     *     <li>{@link #evaluate(FunctionExpressionName, List)} throws</li>
+     *     <li>{@link #evaluateFunction(FunctionExpressionName, List)} throws</li>
      *     <li>{@link #prepareParameter(ExpressionFunctionParameter, Object)} throws</li>
      * </ul>
      */

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
@@ -102,7 +102,7 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         assertThrows(
                 NullPointerException.class,
                 () -> this.createContext()
-                        .evaluate(
+                        .evaluateFunction(
                                 null,
                                 ExpressionEvaluationContext.NO_PARAMETERS
                         )
@@ -114,7 +114,7 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         assertThrows(
                 UnknownExpressionFunctionException.class,
                 () -> this.createContext()
-                        .evaluate(
+                        .evaluateFunction(
                                 this.unknownFunctionName(),
                                 ExpressionEvaluationContext.NO_PARAMETERS
                         )
@@ -126,7 +126,7 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         assertThrows(
                 NullPointerException.class,
                 () -> this.createContext()
-                        .evaluate(
+                        .evaluateFunction(
                                 FunctionExpressionName.with("sum"),
                                 null
                         )
@@ -146,7 +146,7 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
                                   final List<Object> parameters,
                                   final Object expected) {
 
-        this.evaluateAndCheck(
+        this.evaluateFunctionAndCheck(
                 this.createContext(),
                 name,
                 parameters,
@@ -154,14 +154,14 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         );
     }
 
-    default void evaluateAndCheck(final C context,
-                                  final FunctionExpressionName name,
-                                  final List<Object> parameters,
-                                  final Object expected) {
+    default void evaluateFunctionAndCheck(final C context,
+                                          final FunctionExpressionName name,
+                                          final List<Object> parameters,
+                                          final Object expected) {
 
         this.checkEquals(
                 expected,
-                context.evaluate(name, parameters),
+                context.evaluateFunction(name, parameters),
                 () -> "evaluate " + name + " " + parameters
         );
     }

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -62,7 +62,7 @@ public class FakeExpressionEvaluationContext extends FakeExpressionNumberConvert
     }
 
     @Override
-    public Object evaluate(final FunctionExpressionName name, final List<Object> parameters) {
+    public Object evaluateFunction(final FunctionExpressionName name, final List<Object> parameters) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(parameters, "parameters");
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContext.java
@@ -113,8 +113,8 @@ final class BasicNodeSelectorExpressionEvaluationContext<N extends Node<N, NAME,
      * Before invoking the namedFunction identified by the given {@link FunctionExpressionName} parameters are resolved
      */
     @Override
-    public Object evaluate(final FunctionExpressionName name,
-                           final List<Object> parameters) {
+    public Object evaluateFunction(final FunctionExpressionName name,
+                                   final List<Object> parameters) {
         final ExpressionFunction<?, ExpressionEvaluationContext> function = this.function(name);
 
         return function.apply(

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -177,10 +177,10 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
         );
     }
 
-    // evaluate namedFunction...............................................................................................
+    // evaluateFunction.................................................................................................
 
     @Test
-    public void testEvaluate() {
+    public void testEvaluateFunction() {
         this.evaluateAndCheck(
                 this.functionName(),
                 this.parameters(),
@@ -189,11 +189,11 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     }
 
     @Test
-    public void testEvaluateThrownHandled() {
+    public void testEvaluateFunctionThrownHandled() {
         final String error = "**ERROR**";
         final FunctionExpressionName name = FunctionExpressionName.with("throws");
 
-        this.evaluateAndCheck(
+        this.evaluateFunctionAndCheck(
                 this.createContext(
                         (n) -> new FakeExpressionFunction<>() {
                             @Override
@@ -404,7 +404,7 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
 
         final FunctionExpressionName name = FunctionExpressionName.with("test123");
 
-        this.evaluateAndCheck(
+        this.evaluateFunctionAndCheck(
                 BasicExpressionEvaluationContext.with(
                         kind,
                         (n) -> new FakeExpressionFunction<>() {

--- a/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
@@ -142,7 +142,7 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
                                 };
                             }
 
-                            public Object evaluate(final FunctionExpressionName name, final List<Object> parameters) {
+                            public Object evaluateFunction(final FunctionExpressionName name, final List<Object> parameters) {
                                 Objects.requireNonNull(name, "name");
                                 Objects.requireNonNull(parameters, "parameters");
 
@@ -282,8 +282,8 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
             }
 
             @Override
-            public Object evaluate(final FunctionExpressionName name,
-                                   final List<Object> parameters) {
+            public Object evaluateFunction(final FunctionExpressionName name,
+                                           final List<Object> parameters) {
                 return this.function(name)
                         .apply(parameters, this);
             }

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -76,13 +76,13 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
     }
 
     @Test
-    public void testEvaluate() {
+    public void testEvaluateFunction() {
         final FunctionExpressionName name = FunctionExpressionName.with("sum");
         final List<Object> parameters = Lists.of("param-1", "param-2");
 
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
             @Override
-            public Object evaluate(final FunctionExpressionName n, final List<Object> p) {
+            public Object evaluateFunction(final FunctionExpressionName n, final List<Object> p) {
                 assertSame(name, n, "name");
                 assertSame(parameters, p, "parameters");
 
@@ -90,7 +90,7 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
             }
         });
 
-        this.evaluateAndCheck(
+        this.evaluateFunctionAndCheck(
                 context,
                 name,
                 parameters,
@@ -356,8 +356,8 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                     }
 
                     @Override
-                    public Object evaluate(final FunctionExpressionName name,
-                                           final List<Object> parameters) {
+                    public Object evaluateFunction(final FunctionExpressionName name,
+                                                   final List<Object> parameters) {
                         Objects.requireNonNull(name, "name");
                         Objects.requireNonNull(parameters, "parameters");
 


### PR DESCRIPTION
- ExpressionEvaluationContext.evaluate(Expression) keeps old method name.