### PR TITLE
CallExpression support for executing functions

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BinaryExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/BinaryExpression.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.expression;
 
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 
 import java.util.List;
 import java.util.Objects;
@@ -79,16 +80,9 @@ abstract class BinaryExpression extends ParentFixedExpression {
 
     // Evaluation ...................................................................................................
 
-    /**
-     * {@link BinaryExpression} sub classes should not receive any call parameters, the values are actually already
-     * children.
-     */
-    @Override final Object call(final List<Expression> parameters,
-                                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
+    @Override
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/CallExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/CallExpression.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.expression;
 
 import walkingkooka.Cast;
 import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
@@ -122,6 +123,11 @@ public final class CallExpression extends VariableExpression {
     // evaluation .....................................................................................................
 
     @Override
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return CallExpressionExpressionFunction.with(this);
+    }
+
+    @Override
     public boolean toBoolean(final ExpressionEvaluationContext context) {
         return this.executeFunctionAndConvert(
                 context,
@@ -147,11 +153,11 @@ public final class CallExpression extends VariableExpression {
 
     @Override
     public Object toValue(final ExpressionEvaluationContext context) {
-        return this.callable()
-                .call(
-                        this.value(),
-                        context
-                );
+        return context.evaluateFunction(
+                this.callable()
+                        .function(context),
+                Cast.to(this.value())
+        );
     }
 
     private <T> T executeFunctionAndConvert(final ExpressionEvaluationContext context,

--- a/src/main/java/walkingkooka/tree/expression/CallExpressionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/CallExpressionExpressionFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameterName;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This is the {@link ExpressionFunction} returned by {@link CallExpression#function(ExpressionEvaluationContext)}.
+ */
+final class CallExpressionExpressionFunction implements ExpressionFunction<Object, ExpressionEvaluationContext> {
+
+    static CallExpressionExpressionFunction with(final CallExpression expression) {
+        return new CallExpressionExpressionFunction(expression);
+    }
+
+    private CallExpressionExpressionFunction(final CallExpression expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public List<ExpressionFunctionParameter<?>> parameters(final int count) {
+        return VALUES; // all objects
+    }
+
+    private final static List<ExpressionFunctionParameter<?>> VALUES = Lists.of(
+            ExpressionFunctionParameterName.VALUE.variable(Object.class)
+    );
+
+    @Override
+    public Class<Object> returnType() {
+        return Object.class;
+    }
+
+    public Object apply(final List<Object> parameterValues,
+                        final ExpressionEvaluationContext context) {
+        final Object tryEvaluateFunction = this.expression.toValue(context);
+
+        if (!(tryEvaluateFunction instanceof ExpressionFunction)) {
+            throw new IllegalArgumentException("Call requires function but got " + CharSequences.quoteIfChars(tryEvaluateFunction));
+        }
+
+        return context.evaluateFunction(
+                Cast.to(tryEvaluateFunction),
+                Cast.to(parameterValues)
+        );
+    }
+
+    @Override
+    public Optional<FunctionExpressionName> name() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isPure(final ExpressionPurityContext context) {
+        return this.expression.isPure(context);
+    }
+
+    @Override
+    public String toString() {
+        return this.expression + "()";
+    }
+
+    private final CallExpression expression;
+}

--- a/src/main/java/walkingkooka/tree/expression/Expression.java
+++ b/src/main/java/walkingkooka/tree/expression/Expression.java
@@ -24,6 +24,7 @@ import walkingkooka.naming.Name;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 import walkingkooka.tree.Node;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
 import walkingkooka.tree.select.NodeSelector;
 import walkingkooka.tree.select.parser.NodeSelectorExpressionParserToken;
@@ -483,25 +484,15 @@ public abstract class Expression implements Node<Expression, FunctionExpressionN
     // Eval................................................................................................................
 
     /**
-     * Called by {@link CallExpression#toValue(ExpressionEvaluationContext)}.
+     * Prepares this {@link Expression} as a {@link ExpressionFunction} ready to be executed.
      */
-    abstract Object call(final List<Expression> parameters,
-                         final ExpressionEvaluationContext context);
+    abstract ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context);
 
     /**
-     * All {@link Expression} that are not a lambda or named function will invoke this, verifying no parameters.
+     * Factory that returns a {@link ExpressionFunction} that expects no parameters and calls {@link Expression#toValue(ExpressionEvaluationContext)}.
      */
-    final Object callRequiringNoParameters(final List<Expression> parameters,
-                                           final ExpressionEvaluationContext context) {
-        this.checkNoParameters(parameters);
-        return this.toValue(context);
-    }
-
-    final void checkNoParameters(final List<Expression> parameters) {
-        final int count = parameters.size();
-        if (count > 0) {
-            throw new IllegalArgumentException("Expected no parameters but got " + count);
-        }
+    final ExpressionFunction<?, ExpressionEvaluationContext> toValueFunction() {
+        return ExpressionExpressionFunction.with(this);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/ExpressionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionExpressionFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This is the {@link ExpressionFunction} returned by {@link Expression#function(ExpressionEvaluationContext)} for all sub classes except
+ * {@link CallExpression}.
+ */
+final class ExpressionExpressionFunction implements ExpressionFunction<Object, ExpressionEvaluationContext> {
+
+    static ExpressionExpressionFunction with(final Expression expression) {
+        return new ExpressionExpressionFunction(expression);
+    }
+
+    private ExpressionExpressionFunction(final Expression expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public List<ExpressionFunctionParameter<?>> parameters(final int count) {
+        return ExpressionFunctionParameter.EMPTY;
+    }
+
+    @Override
+    public Class<Object> returnType() {
+        return Object.class;
+    }
+
+    public Object apply(final List<Object> parameterValues,
+                        final ExpressionEvaluationContext context) {
+        this.parameters(parameterValues.size());
+
+        return this.expression.toValue(context);
+    }
+
+    @Override
+    public Optional<FunctionExpressionName> name() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isPure(final ExpressionPurityContext context) {
+        return this.expression.isPure(context);
+    }
+
+    @Override
+    public String toString() {
+        return this.expression + "()";
+    }
+
+    private final Expression expression;
+}

--- a/src/main/java/walkingkooka/tree/expression/LambdaFunctionExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/LambdaFunctionExpression.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.tree.expression.function.ExpressionFunction;
@@ -112,18 +111,11 @@ public final class LambdaFunctionExpression extends UnaryExpression {
     // evaluation .....................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-
-        final ExpressionFunction<?, ExpressionEvaluationContext> lambdaFunction = context.lambdaFunction(
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return context.lambdaFunction(
                 this.parameters,
                 Object.class,
                 this.value()
-        );
-
-        return context.evaluateFunction(
-                lambdaFunction,
-                Cast.to(parameters)
         );
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ListExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ListExpression.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
@@ -93,6 +94,11 @@ public final class ListExpression extends VariableExpression {
     }
 
     // evaluation .....................................................................................................
+
+    @Override
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
+    }
 
     @Override
     public boolean toBoolean(final ExpressionEvaluationContext context) {

--- a/src/main/java/walkingkooka/tree/expression/NamedFunctionExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/NamedFunctionExpression.java
@@ -17,9 +17,8 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -94,12 +93,8 @@ final public class NamedFunctionExpression extends LeafExpression<FunctionExpres
     // toXXX............................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-        return context.evaluateFunction(
-                context.function(this.value()),
-                Cast.to(parameters)
-        );
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return context.function(this.value);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/NegativeExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/NegativeExpression.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
@@ -74,12 +75,8 @@ public final class NegativeExpression extends UnaryExpression {
     // evaluation .....................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/NotExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/NotExpression.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
@@ -74,12 +75,8 @@ public final class NotExpression extends UnaryExpression {
     // evaluation .....................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ReferenceExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ReferenceExpression.java
@@ -17,7 +17,8 @@
 
 package walkingkooka.tree.expression;
 
-import java.util.List;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+
 import java.util.Objects;
 
 /**
@@ -86,12 +87,8 @@ public final class ReferenceExpression extends LeafExpression<ExpressionReferenc
     // evaluation .....................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ValueExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ValueExpression.java
@@ -18,8 +18,8 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.text.CharSequences;
+import walkingkooka.tree.expression.function.ExpressionFunction;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -83,12 +83,8 @@ final public class ValueExpression<V> extends LeafExpression<V> {
     // toXXX............................................................................................................
 
     @Override
-    Object call(final List<Expression> parameters,
-                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
+    ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionEvaluationContext context) {
+        return this.toValueFunction();
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/VariableExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/VariableExpression.java
@@ -43,16 +43,6 @@ abstract class VariableExpression extends ParentExpression implements Value<List
         }
     }
 
-    // evaluation.......................................................................................................
-
-    @Override final Object call(final List<Expression> parameters,
-                                final ExpressionEvaluationContext context) {
-        return this.callRequiringNoParameters(
-                parameters,
-                context
-        );
-    }
-
     // Object........................................................................................................
 
     @Override final boolean canBeEqual(final Object other) {

--- a/src/test/java/walkingkooka/tree/expression/CallExpressionExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CallExpressionExpressionFunctionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class CallExpressionExpressionFunctionTest implements ClassTesting<CallExpressionExpressionFunction> {
+
+    @Override
+    public Class<CallExpressionExpressionFunction> type() {
+        return CallExpressionExpressionFunction.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/tree/expression/ExpressionExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionExpressionFunctionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class ExpressionExpressionFunctionTest implements ClassTesting<ExpressionExpressionFunction> {
+
+    @Override
+    public Class<ExpressionExpressionFunction> type() {
+        return ExpressionExpressionFunction.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}


### PR DESCRIPTION
- Call now supports executing lambda functions returned by other functions.
- All Expressions now support returning themselves as a lambda (less CallFunctionExpression & LambdaFunctionExpression) requiring no parameters.