### PR TITLE
ExpressionFunctionParameter.get returns Optional<Optional<T>>

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
@@ -228,13 +228,19 @@ public final class ExpressionFunctionParameter<T> implements HasName<ExpressionF
      * <br>
      * Note the index is not validated against the correct position of this parameter within the parameter list.
      */
-    public Optional<T> get(final List<Object> parameters,
-                           final int index) {
+    public Optional<Optional<T>> get(final List<Object> parameters,
+                                     final int index) {
         this.cardinality.get(this);
 
         return index >= parameters.size() ?
                 Optional.empty() :
-                Optional.of(Cast.to(parameters.get(index)));
+                Optional.of(
+                        Optional.ofNullable(
+                                Cast.to(
+                                        parameters.get(index)
+                                )
+                        )
+                );
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
@@ -33,6 +33,7 @@ import walkingkooka.tree.expression.ExpressionEvaluationContexts;
 import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -380,7 +381,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
     }
 
     @Test
-    public void testGet() {
+    public void testGetNonNull() {
         final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(
                 NAME,
                 Integer.class,
@@ -389,13 +390,59 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 KINDS
         );
         this.checkEquals(
-                Optional.of(100),
+                Optional.of(
+                        Optional.of(100)
+                ),
                 parameter.get(
                         List.of(
                                 100,
                                 "B"
                         ),
                         0
+                )
+        );
+    }
+
+    @Test
+    public void testGetNull() {
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(
+                NAME,
+                Integer.class,
+                TYPE_PARAMETERS,
+                ExpressionFunctionParameterCardinality.OPTIONAL,
+                KINDS
+        );
+        this.checkEquals(
+                Optional.of(
+                        Optional.empty()
+                ),
+                parameter.get(
+                        Arrays.asList(
+                                null,
+                                "B"
+                        ),
+                        0
+                )
+        );
+    }
+
+    @Test
+    public void testGetAbsent() {
+        final ExpressionFunctionParameter<Integer> parameter = ExpressionFunctionParameter.with(
+                NAME,
+                Integer.class,
+                TYPE_PARAMETERS,
+                ExpressionFunctionParameterCardinality.OPTIONAL,
+                KINDS
+        );
+        this.checkEquals(
+                Optional.empty(),
+                parameter.get(
+                        List.of(
+                                100,
+                                "B"
+                        ),
+                        99
                 )
         );
     }


### PR DESCRIPTION
- Previously optional parameters values returned Optional for both an absent parameter and a null.

- Closes https://github.com/mP1/walkingkooka-tree/issues/628
- ExpressionFunctionParameter.get should return Optional<Optional<T>> currently Optional<T>