### PR TITLE
ExpressionEvaluationContext.resolveReference returns Optional<Optiona…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -46,7 +46,7 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     static BasicExpressionEvaluationContext with(final ExpressionNumberKind expressionNumberKind,
                                                  final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                                  final Function<RuntimeException, Object> exceptionHandler,
-                                                 final Function<ExpressionReference, Optional<Object>> references,
+                                                 final Function<ExpressionReference, Optional<Optional<Object>>> references,
                                                  final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                                  final CaseSensitivity caseSensitivity,
                                                  final ConverterContext converterContext) {
@@ -75,7 +75,7 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     private BasicExpressionEvaluationContext(final ExpressionNumberKind expressionNumberKind,
                                              final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                              final Function<RuntimeException, Object> exceptionHandler,
-                                             final Function<ExpressionReference, Optional<Object>> references,
+                                             final Function<ExpressionReference, Optional<Optional<Object>>> references,
                                              final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                              final CaseSensitivity caseSensitivity,
                                              final ConverterContext converterContext) {
@@ -238,7 +238,7 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     // functions........................................................................................................
 
     @Override
-    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Object>> resolver) {
+    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Optional<Object>>> resolver) {
         throw new UnsupportedOperationException("https://github.com/mP1/walkingkooka-tree/issues/599");
     }
 
@@ -285,11 +285,11 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     private final Function<RuntimeException, Object> exceptionHandler;
 
     @Override
-    public Optional<Object> reference(final ExpressionReference reference) {
+    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
         return this.references.apply(reference);
     }
 
-    private final Function<ExpressionReference, Optional<Object>> references;
+    private final Function<ExpressionReference, Optional<Optional<Object>>> references;
 
     @Override
     public ExpressionEvaluationException referenceNotFound(final ExpressionReference reference) {

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextScopedReferencesFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextScopedReferencesFunction.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-final class ExpressionEvaluationContextScopedReferencesFunction implements Function<ExpressionReference, Optional<Object>> {
+final class ExpressionEvaluationContextScopedReferencesFunction implements Function<ExpressionReference, Optional<Optional<Object>>> {
 
     static ExpressionEvaluationContextScopedReferencesFunction with(final List<ExpressionFunctionParameter<?>> parameters,
                                                                     final List<Object> values) {
@@ -40,15 +40,17 @@ final class ExpressionEvaluationContextScopedReferencesFunction implements Funct
     }
 
     @Override
-    public Optional<Object> apply(final ExpressionReference reference) {
-        Object value = null;
+    public Optional<Optional<Object>> apply(final ExpressionReference reference) {
+        Optional<Object> value = null;
 
         int i = 0;
         for (final ExpressionFunctionParameter<?> parameter : this.parameters) {
             if (reference.testParameterName(
                     parameter.name()
             )) {
-                value = this.values.get(i); // TODO need to special case null being returned here.
+                value = Optional.ofNullable(
+                        this.values.get(i)
+                );
                 break;
             }
             i++;

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
@@ -33,7 +33,7 @@ public final class ExpressionEvaluationContexts implements PublicStaticHelper {
     public static ExpressionEvaluationContext basic(final ExpressionNumberKind expressionNumberKind,
                                                     final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                                     final Function<RuntimeException, Object> exceptionHandler,
-                                                    final Function<ExpressionReference, Optional<Object>> references,
+                                                    final Function<ExpressionReference, Optional<Optional<Object>>> references,
                                                     final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound,
                                                     final CaseSensitivity caseSensitivity,
                                                     final ConverterContext converterContext) {

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -38,7 +38,7 @@ public class FakeExpressionEvaluationContext extends FakeExpressionNumberConvert
     }
 
     @Override
-    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Object>> scoped) {
+    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
         throw new UnsupportedOperationException();
     }
 
@@ -87,8 +87,9 @@ public class FakeExpressionEvaluationContext extends FakeExpressionNumberConvert
     }
 
     @Override
-    public Optional<Object> reference(final ExpressionReference reference) {
+    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
+
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/function/LambdaExpressionFunctionExpressionEvaluationContextContextFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/LambdaExpressionFunctionExpressionEvaluationContextContextFunction.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * A {@link Function} that handles translating {@link ExpressionReference} into possible values and is given to {@link walkingkooka.tree.expression.ExpressionEvaluationContext#context(Function)}
  * for that purpose.
  */
-final class LambdaExpressionFunctionExpressionEvaluationContextContextFunction implements Function<ExpressionReference, Optional<Object>> {
+final class LambdaExpressionFunctionExpressionEvaluationContextContextFunction implements Function<ExpressionReference, Optional<Optional<Object>>> {
 
     static LambdaExpressionFunctionExpressionEvaluationContextContextFunction with(final List<ExpressionFunctionParameter<?>> parameters,
                                                                                    final List<Object> values) {
@@ -44,8 +44,8 @@ final class LambdaExpressionFunctionExpressionEvaluationContextContextFunction i
     }
 
     @Override
-    public Optional<Object> apply(final ExpressionReference reference) {
-        Object value = null;
+    public Optional<Optional<Object>> apply(final ExpressionReference reference) {
+        Optional<Object> value = null;
 
         int i = 0;
 
@@ -53,7 +53,9 @@ final class LambdaExpressionFunctionExpressionEvaluationContextContextFunction i
             if (reference.testParameterName(
                     parameter.name()
             )) {
-                value = this.values.get(i); // TODO need to special case null being returned here.
+                value = Optional.ofNullable(
+                        this.values.get(i)
+                );
                 break;
             }
             i++;

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextReferenceFunction.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextReferenceFunction.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 final class BasicNodeSelectorExpressionEvaluationContextReferenceFunction<N extends Node<N, NAME, ANAME, AVALUE>,
         NAME extends Name,
         ANAME extends Name,
-        AVALUE> implements Function<ExpressionReference, Optional<Object>> {
+        AVALUE> implements Function<ExpressionReference, Optional<Optional<Object>>> {
 
     static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
@@ -46,7 +46,7 @@ final class BasicNodeSelectorExpressionEvaluationContextReferenceFunction<N exte
     }
 
     @Override
-    public Optional<Object> apply(final ExpressionReference reference) {
+    public Optional<Optional<Object>> apply(final ExpressionReference reference) {
         return context.reference(reference);
     }
 

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorExpressionEvaluationContexts.java
@@ -37,7 +37,7 @@ public final class NodeSelectorExpressionEvaluationContexts implements PublicSta
             NAME extends Name,
             ANAME extends Name,
             AVALUE> NodeSelectorExpressionEvaluationContext<N, NAME, ANAME, AVALUE> basic(final N node,
-                                                                                          final Function<Function<ExpressionReference, Optional<Object>>, ExpressionEvaluationContext> context) {
+                                                                                          final Function<Function<ExpressionReference, Optional<Optional<Object>>>, ExpressionEvaluationContext> context) {
         return BasicNodeSelectorExpressionEvaluationContext.with(node, context);
     }
 

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -483,7 +483,9 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     @Test
     public void testReferences() {
         this.checkEquals(
-                Optional.of(REFERENCE_VALUE),
+                Optional.of(
+                        Optional.of(REFERENCE_VALUE)
+                ),
                 this.createContext()
                         .reference(REFERENCE)
         );
@@ -529,7 +531,7 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
     @Test
     public void testToString() {
         final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions = this.functions();
-        final Function<ExpressionReference, Optional<Object>> references = this.references();
+        final Function<ExpressionReference, Optional<Optional<Object>>> references = this.references();
         final Function<ExpressionReference, ExpressionEvaluationException> referenceNotFound = ExpressionEvaluationContexts.referenceNotFound();
         final ConverterContext converterContext = this.converterContext();
 
@@ -655,11 +657,14 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
         return "namedFunction-value-234";
     }
 
-    private Function<ExpressionReference, Optional<Object>> references() {
+    private Function<ExpressionReference, Optional<Optional<Object>>> references() {
         return (r -> {
             Objects.requireNonNull(r, "references");
             this.checkEquals(REFERENCE, r, "reference");
-            return Optional.of(REFERENCE_VALUE);
+
+            return Optional.of(
+                    Optional.of(REFERENCE_VALUE)
+            );
         });
     }
 

--- a/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
@@ -290,7 +290,7 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Object>> scoped) {
+                    public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
                         return new FakeExpressionEvaluationContext() {
 
                             @Override
@@ -315,7 +315,7 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
                             }
 
                             @Override
-                            public Optional<Object> reference(final ExpressionReference reference) {
+                            public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                                 return scoped.apply(reference);
                             }
                         };

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -131,12 +131,19 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         assertSame(A1, reference, "reference");
-                        return Optional.of(target);
+
+                        return Optional.of(
+                                Optional.of(target
+                                )
+                        );
                     }
                 });
-        assertSame(target, context.reference(A1).orElse(null));
+        this.checkEquals(
+                Optional.of(target),
+                context.reference(A1).orElse(null)
+        );
     }
 
     @Test
@@ -148,10 +155,12 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         if (A1 == reference) {
                             return Optional.of(
-                                    target.value()
+                                    Optional.of(
+                                            target.value()
+                                    )
                             );
                         }
                         return this.unknownReference(reference);
@@ -179,8 +188,12 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
-                        return Optional.of(this.reference0(reference));
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
+                        return Optional.of(
+                                Optional.of(
+                                        this.reference0(reference)
+                                )
+                        );
                     }
 
                     private Object reference0(final ExpressionReference reference) {
@@ -213,9 +226,11 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         return Optional.of(
-                                this.reference0(reference)
+                                Optional.of(
+                                        this.reference0(reference)
+                                )
                         );
                     }
 
@@ -259,9 +274,11 @@ public final class CycleDetectingExpressionEvaluationContextTest implements Clas
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         return Optional.of(
-                                this.reference0(reference)
+                                Optional.of(
+                                        this.reference0(reference)
+                                )
                         );
                     }
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListFlattenedTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListFlattenedTest.java
@@ -499,10 +499,13 @@ public final class ExpressionEvaluationContextPrepareParametersListFlattenedTest
                 new FakeExpressionEvaluationContext() {
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         checkEquals(REFERENCE, reference);
+
                         return Optional.of(
-                                Expression.value("Twenty"
+                                Optional.of(
+                                        Expression.value("Twenty"
+                                        )
                                 )
                         );
                     }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextPrepareParametersListTestCase.java
@@ -70,10 +70,10 @@ public abstract class ExpressionEvaluationContextPrepareParametersListTestCase<T
         return new FakeExpressionEvaluationContext() {
 
             @Override
-            public Optional<Object> reference(final ExpressionReference r) {
+            public Optional<Optional<Object>> reference(final ExpressionReference r) {
                 return Optional.ofNullable(
                         reference.equals(r) ?
-                                value :
+                                Optional.ofNullable(value) :
                                 null
                 );
             }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationContextTest.java
@@ -104,13 +104,15 @@ public final class ExpressionEvaluationContextTest implements ClassTesting<Expre
         this.evaluateIfNecessary(
                 new FakeExpressionEvaluationContext() {
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         checkEquals(
                                 input,
                                 reference,
                                 "reference"
                         );
-                        return Optional.of(output);
+                        return Optional.of(
+                                Optional.of(output)
+                        );
                     }
                 },
                 input,
@@ -130,14 +132,16 @@ public final class ExpressionEvaluationContextTest implements ClassTesting<Expre
         this.evaluateIfNecessary(
                 new FakeExpressionEvaluationContext() {
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         checkEquals(
                                 input,
                                 reference,
                                 "reference"
                         );
                         return Optional.of(
-                                Expression.value(output)
+                                Optional.of(
+                                        Expression.value(output)
+                                )
                         );
                     }
 
@@ -214,7 +218,7 @@ public final class ExpressionEvaluationContextTest implements ClassTesting<Expre
     public void testLambdaFunction() {
         final FakeExpressionEvaluationContext context = new FakeExpressionEvaluationContext() {
             @Override
-            public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Object>> scoped) {
+            public ExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
                 return new FakeExpressionEvaluationContext() {
 
                     @Override

--- a/src/test/java/walkingkooka/tree/expression/LambdaFunctionExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/LambdaFunctionExpressionTest.java
@@ -179,12 +179,16 @@ public final class LambdaFunctionExpressionTest extends UnaryExpressionTestCase<
                     }
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         switch (reference.toString()) {
                             case "x":
-                                return Optional.of(10);
+                                return Optional.of(
+                                        Optional.of(10)
+                                );
                             case "y":
-                                return Optional.of(20);
+                                return Optional.of(
+                                        Optional.of(20)
+                                );
                             default:
                                 throw new IllegalArgumentException("Unknown reference: " + reference);
                         }

--- a/src/test/java/walkingkooka/tree/expression/ReferenceExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ReferenceExpressionTest.java
@@ -159,10 +159,12 @@ public final class ReferenceExpressionTest extends LeafExpressionTestCase<Refere
         return new FakeExpressionEvaluationContext() {
 
             @Override
-            public Optional<Object> reference(final ExpressionReference reference) {
+            public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                 checkEquals(value, reference, "reference");
                 return Optional.of(
-                        referenceText
+                        Optional.of(
+                                referenceText
+                        )
                 );
             }
 

--- a/src/test/java/walkingkooka/tree/expression/function/LambdaExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/LambdaExpressionFunctionTest.java
@@ -165,7 +165,7 @@ public class LambdaExpressionFunctionTest implements ExpressionFunctionTesting<L
         return new FakeExpressionEvaluationContext() {
 
             @Override
-            public FakeExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Object>> scoped) {
+            public FakeExpressionEvaluationContext context(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
                 return new FakeExpressionEvaluationContext() {
 
                     @Override
@@ -189,7 +189,7 @@ public class LambdaExpressionFunctionTest implements ExpressionFunctionTesting<L
                     }
 
                     @Override
-                    public Optional<Object> reference(final ExpressionReference reference) {
+                    public Optional<Optional<Object>> reference(final ExpressionReference reference) {
                         return scoped.apply(reference);
                     }
                 };

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
@@ -200,7 +200,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
                 };
             }
 
-            private Function<ExpressionReference, Optional<Object>> references() {
+            private Function<ExpressionReference, Optional<Optional<Object>>> references() {
                 return (r) -> Optional.empty();
             }
 

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorExpressionEvaluationContextTest.java
@@ -150,7 +150,7 @@ public final class BasicNodeSelectorExpressionEvaluationContextTest implements N
         };
     }
 
-    private Function<ExpressionReference, Optional<Object>> references() {
+    private Function<ExpressionReference, Optional<Optional<Object>>> references() {
         return (r -> {
             throw new UnsupportedOperationException();
         });

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1923,7 +1923,7 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
                         };
                     }
 
-                    private Function<ExpressionReference, Optional<Object>> references() {
+                    private Function<ExpressionReference, Optional<Optional<Object>>> references() {
                         return (r -> {
                             throw new UnsupportedOperationException();
                         });

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
@@ -449,7 +449,7 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
         };
     }
 
-    private Function<ExpressionReference, Optional<Object>> references() {
+    private Function<ExpressionReference, Optional<Optional<Object>>> references() {
         return (r -> {
             throw new UnsupportedOperationException();
         });


### PR DESCRIPTION
…l<Object>>

- ExpressionEvaluationContext.context(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) return type also updated.

- Closes https://github.com/mP1/walkingkooka-tree/issues/603
- ExpressionEvaluationContext.reference needs a way to return Optional with a null value.