### PR TITLE
ExpressionNumberContext unnecessary implements HasMathContext removed

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberContext.java
@@ -18,9 +18,7 @@
 package walkingkooka.tree.expression;
 
 import walkingkooka.math.DecimalNumberContext;
-import walkingkooka.math.HasMathContext;
 
 public interface ExpressionNumberContext extends HasExpressionNumberKind,
-        HasMathContext,
         DecimalNumberContext {
 }


### PR DESCRIPTION
- DecimalNumberContext already implements HasMathContext.