### PR TITLE
ExpressionNumberFromConverter double wrap guard

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberFromConverter.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberFromConverter.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression;
 
+import walkingkooka.Cast;
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 
@@ -31,11 +32,14 @@ final class ExpressionNumberFromConverter<C extends ExpressionNumberConverterCon
 
     /**
      * Wraps another {@link Converter}, which will receive the actual value of the {@link ExpressionNumber}.
+     * Note if the converter is already a {@link ExpressionNumberFromConverter} it will not be double wrapped.
      */
     static <C extends ExpressionNumberConverterContext> ExpressionNumberFromConverter<C> with(final Converter<C> converter) {
         Objects.requireNonNull(converter, "converter");
 
-        return new ExpressionNumberFromConverter<>(converter);
+        return converter instanceof ExpressionNumberFromConverter ?
+                Cast.to(converter) :
+                new ExpressionNumberFromConverter<>(converter);
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberFromConverterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberFromConverterTest.java
@@ -34,6 +34,7 @@ import java.math.MathContext;
 import java.text.DecimalFormat;
 import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ExpressionNumberFromConverterTest implements ConverterTesting2<ExpressionNumberFromConverter<ExpressionNumberConverterContext>, ExpressionNumberConverterContext>,
@@ -46,6 +47,17 @@ public final class ExpressionNumberFromConverterTest implements ConverterTesting
                 () -> ExpressionNumberFromConverter.with(null)
         );
     }
+
+    @Test
+    public void testWithExpressionNumberFromConverter() {
+        final ExpressionNumberFromConverter<ExpressionNumberConverterContext> converter = this.createConverter();
+        assertSame(
+                converter,
+                ExpressionNumberFromConverter.with(converter)
+        );
+    }
+
+    // convert..........................................................................................................
 
     @Test
     public void testConvertFails() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/736
- ExpressionNumberFromConverter.with should not wrap another ExpressionNumberFromConverter