### PR TITLE
ExpressionNumberToConverter.with double wrap guard

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNumberToConverter.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNumberToConverter.java
@@ -43,7 +43,9 @@ final class ExpressionNumberToConverter<C extends ExpressionNumberConverterConte
     static <C extends ExpressionNumberConverterContext> ExpressionNumberToConverter<C> with(final Converter<C> converter) {
         Objects.requireNonNull(converter, "converter");
 
-        return new ExpressionNumberToConverter<>(converter);
+        return converter instanceof ExpressionNumberToConverter ?
+                Cast.to(converter) :
+                new ExpressionNumberToConverter<>(converter);
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberToConverterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberToConverterTest.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ExpressionNumberToConverterTest implements ConverterTesting2<ExpressionNumberToConverter<ExpressionNumberConverterContext>, ExpressionNumberConverterContext>,
@@ -42,6 +43,17 @@ public final class ExpressionNumberToConverterTest implements ConverterTesting2<
     public void testWithNullConverterFails() {
         assertThrows(NullPointerException.class, () -> ExpressionNumberToConverter.with(null));
     }
+
+    @Test
+    public void testWithExpressionNumberToConverter() {
+        final ExpressionNumberToConverter<ExpressionNumberConverterContext> converter = this.createConverter();
+        assertSame(
+                converter,
+                ExpressionNumberToConverter.with(converter)
+        );
+    }
+
+    // convert..........................................................................................................
 
     @Test
     public void testConvertersSimpleFails() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/735
- ExpressionNumberToConverter.with should not wrap another ExpressionNumberToConverter