### PR TITLE
Expression.equals removed ancestors

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BinaryExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/BinaryExpression.java
@@ -127,8 +127,9 @@ abstract class BinaryExpression extends ParentFixedExpression {
 
     // Object........................................................................................................
 
-    @Override final boolean equalsIgnoringParentAndChildren(final Expression other) {
-        return true; // no other properties name already tested.
+    @Override //
+    final boolean equalsIgnoringChildren(final Expression other) {
+        return true; // no other properties name was already tested.
     }
 
     final void toString0(final StringBuilder b) {

--- a/src/main/java/walkingkooka/tree/expression/CallExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/CallExpression.java
@@ -203,7 +203,7 @@ public final class CallExpression extends VariableExpression {
     // Object.........................................................................................................
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final Expression other) {
+    boolean equalsIgnoringChildren(final Expression other) {
         return this.equalsIgnoringParentAndChildren0(Cast.to(other));
     }
 

--- a/src/main/java/walkingkooka/tree/expression/Expression.java
+++ b/src/main/java/walkingkooka/tree/expression/Expression.java
@@ -551,43 +551,20 @@ public abstract class Expression implements Node<Expression, FunctionExpressionN
     abstract boolean canBeEqual(final Object other);
 
     private boolean equals0(final Expression other) {
-        return this.equalsAncestors(other) &&
-                this.equalsDescendants0(other);
+        return this.equalsIgnoringChildren(other) &&
+                this.equalsChildren(other);
     }
-
-    private boolean equalsAncestors(final Expression other) {
-        boolean result = this.equalsIgnoringParentAndChildren(other);
-
-        if (result) {
-            final Optional<Expression> parent = this.parent();
-            final Optional<Expression> otherParent = other.parent();
-            final boolean hasParent = parent.isPresent();
-            final boolean hasOtherParent = otherParent.isPresent();
-
-            if (hasParent) {
-                if (hasOtherParent) {
-                    result = parent.get().equalsAncestors(otherParent.get());
-                }
-            } else {
-                // result is only true if other is false
-                result = !hasOtherParent;
-            }
-        }
-
-        return result;
-    }
-
-    final boolean equalsDescendants(final Expression other) {
-        return this.equalsIgnoringParentAndChildren(other) &&
-                this.equalsDescendants0(other);
-    }
-
-    abstract boolean equalsDescendants0(final Expression other);
 
     /**
-     * Sub classes should do equals but ignore the parent and children properties.
+     * This method is only implemented by {@link LeafExpression} which returns true and {@link ParentExpression}
+     * which iterates over its children.
      */
-    abstract boolean equalsIgnoringParentAndChildren(final Expression other);
+    abstract boolean equalsChildren(final Expression other);
+
+    /**
+     * Sub classes should check other properties ignoring any children.
+     */
+    abstract boolean equalsIgnoringChildren(final Expression other);
 
     // Object .......................................................................................................
 

--- a/src/main/java/walkingkooka/tree/expression/LambdaFunctionExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/LambdaFunctionExpression.java
@@ -185,7 +185,7 @@ public final class LambdaFunctionExpression extends UnaryExpression {
     }
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final Expression other) {
+    boolean equalsIgnoringChildren(final Expression other) {
         return this.equalsIgnoringParentAndChildren0((LambdaFunctionExpression) other);
     }
 

--- a/src/main/java/walkingkooka/tree/expression/LeafExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/LeafExpression.java
@@ -94,16 +94,18 @@ abstract class LeafExpression<V> extends Expression implements Value<V> {
         return Objects.hash(this.value);
     }
 
-    @Override final boolean equalsDescendants0(final Expression other) {
+    @Override //
+    final boolean equalsChildren(final Expression other) {
         return true;
     }
 
-    @Override final boolean equalsIgnoringParentAndChildren(final Expression other) {
+    @Override //
+    final boolean equalsIgnoringChildren(final Expression other) {
         return other instanceof LeafExpression &&
-                equalsIgnoringParentAndChildren0(Cast.to(other));
+                equalsChildren0(Cast.to(other));
     }
 
-    private boolean equalsIgnoringParentAndChildren0(final LeafExpression<?> other) {
+    private boolean equalsChildren0(final LeafExpression<?> other) {
         return this.value.equals(other.value);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ListExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ListExpression.java
@@ -143,7 +143,7 @@ public final class ListExpression extends VariableExpression {
     // Object.........................................................................................................
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final Expression other) {
+    boolean equalsIgnoringChildren(final Expression other) {
         return true; // no new properties to equality check
     }
 

--- a/src/main/java/walkingkooka/tree/expression/NegativeExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/NegativeExpression.java
@@ -114,7 +114,7 @@ public final class NegativeExpression extends UnaryExpression {
     }
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final Expression other) {
+    boolean equalsIgnoringChildren(final Expression other) {
         return true; // no other properties name already tested.
     }
 

--- a/src/main/java/walkingkooka/tree/expression/NotExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/NotExpression.java
@@ -114,7 +114,7 @@ public final class NotExpression extends UnaryExpression {
     }
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final Expression other) {
+    boolean equalsIgnoringChildren(final Expression other) {
         return true; // no other properties name already tested.
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ParentExpression.java
+++ b/src/main/java/walkingkooka/tree/expression/ParentExpression.java
@@ -57,7 +57,7 @@ abstract class ParentExpression extends Expression {
         Objects.requireNonNull(children, "children");
 
         final List<Expression> copy = Lists.immutable(children);
-        return Lists.equals(this.children(), copy, (first, other) -> first.equalsIgnoringParentAndChildren(other) && first.equalsDescendants0(other)) ?
+        return Lists.equals(this.children(), copy, (first, other) -> first.equals(other)) ?
                 this :
                 this.replaceChildren(copy);
     }
@@ -65,8 +65,8 @@ abstract class ParentExpression extends Expression {
     @Override
     final Expression setChild(final Expression newChild) {
         final int index = newChild.index();
-        final Expression previous = this.children().get(index);
-        return previous.equalsIgnoringParentAndChildren(newChild) && previous.equalsDescendants(newChild) ?
+
+        return this.children().get(index).equals(newChild) ?
                 this :
                 this.replaceChild0(newChild, index);
     }
@@ -150,24 +150,8 @@ abstract class ParentExpression extends Expression {
         return this.children().hashCode();
     }
 
-    final boolean equalsDescendants0(final Expression other) {
-        return this.equalsDescendants1(other.children());
-    }
-
-    /**
-     * Only returns true if the descendants of this node and the given children are equal ignoring the parents.
-     */
-    private boolean equalsDescendants1(final List<Expression> otherChildren) {
-        final List<Expression> children = this.children();
-        final int count = children.size();
-        boolean equals = count == otherChildren.size();
-
-        if (equals) {
-            for (int i = 0; equals && i < count; i++) {
-                equals = children.get(i).equalsDescendants(otherChildren.get(i));
-            }
-        }
-
-        return equals;
+    @Override
+    final boolean equalsChildren(final Expression other) {
+        return this.children.equals(other.children());
     }
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/759
- Expression.equals should NOT include ancestors