### PR TITLE
BasicExpressionEvaluationContext.evaluateFunction Objects.requireNonN…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -201,6 +201,9 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     @Override
     public Object evaluateFunction(final ExpressionFunction<?, ? extends ExpressionEvaluationContext> function,
                                    final List<Object> parameters) {
+        Objects.requireNonNull(function, "function");
+        Objects.requireNonNull(parameters, "parameters");
+
         Object result;
 
         try {


### PR DESCRIPTION
…ull guard

- Previously there was no null check, and null de-references threw NPE.