### PR TITLE
ExpressionEvaluationContextTesting.referenceFails

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContextTesting.java
@@ -217,6 +217,21 @@ public interface ExpressionEvaluationContextTesting<C extends ExpressionEvaluati
         );
     }
 
+    default void referenceFails(final ExpressionEvaluationContext context,
+                                final ExpressionReference reference,
+                                final RuntimeException expected) {
+        final RuntimeException thrown = assertThrows(
+            expected.getClass(),
+            () -> context.reference(reference)
+        );
+
+        this.checkEquals(
+            expected.getClass(),
+            thrown.getMessage(),
+            () -> "reference " + reference
+        );
+    }
+
     // ExpressionEvaluationContext......................................................................................
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree/issues/848
- ExpressionEvaluationContextTesting.referenceNotFoundAndCheck