### PR TITLE
ExpressionFunctionParameter.getXXX Class cast message

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameter.java
@@ -300,15 +300,10 @@ public final class ExpressionFunctionParameter<T> implements HasName<ExpressionF
             throw new IndexOutOfBoundsException("Required parameter " + this.name() + " missing");
         }
 
-        final Object value = parameters.get(index);
-        try {
-            return ExpressionFunctionParameterCast.cast(
-                value,
-                this
-            );
-        } catch (final ClassCastException cast) {
-            throw new ClassCastException("Parameter " + this.name() + " of wrong type " + value.getClass().getName() + " expected " + this.type());
-        }
+        return ExpressionFunctionParameterCast.cast(
+            parameters.get(index),
+            this
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCast.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCast.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression.function;
 
 import javaemul.internal.annotations.GwtIncompatible;
+import walkingkooka.text.CharSequences;
 
 // https://github.com/mP1/walkingkooka-tree/issues/307
 // Emulate Class.cast
@@ -26,7 +27,21 @@ class ExpressionFunctionParameterCast extends ExpressionFunctionParameterCastGwt
     @GwtIncompatible
     static <T> T cast(final Object value,
                       final ExpressionFunctionParameter<T> parameter) {
-        return parameter.type()
-            .cast(value);
+        final Class<T> type = parameter.type();
+        if (null != value && false == type.isInstance(value)) {
+            // Invalid parameter "name" value "Actual" expected "Expected".
+            throw new ClassCastException(
+                "Parameter " +
+                    CharSequences.quoteAndEscape(
+                        parameter.name()
+                            .value()
+                    ) +
+                    ": Invalid type " +
+                    value.getClass().getName() +
+                    " expected " +
+                    type.getName()
+            );
+        }
+        return type.cast(value);
     }
 }


### PR DESCRIPTION
- Updated message to standard format: Invalid parameter "name" value "Actual" expected "Expected".