### PR TITLE
ExpressionNumberFunctionExpressionFunction.NUMBER ExpressionFunctionP…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
@@ -77,7 +77,7 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionEvalu
 
     private final static ExpressionFunctionParameter<ExpressionNumber> NUMBER = ExpressionFunctionParameterName.with("number")
         .required(ExpressionNumber.class)
-        .setKinds(ExpressionFunctionParameterKind.EVALUATE_RESOLVE_REFERENCES);
+        .setKinds(ExpressionFunctionParameterKind.CONVERT_EVALUATE_RESOLVE_REFERENCES);
 
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = ExpressionFunctionParameter.list(NUMBER);
 


### PR DESCRIPTION
…arameterKind.CONVERT added FIX

- sin("4") was failing because the only parameter was missing CONVERT, this the function was executed with a String and not an ExpressionNumber.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7002
- Converter: formula function with number within string parameter fails to be converted