### PR TITLE
ExpressionEvaluationContext.evaluateFunction InvalidExpressionFunctio…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -28,6 +28,7 @@ import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
 import walkingkooka.tree.expression.function.ExpressionFunctionParameterKind;
 import walkingkooka.tree.expression.function.ExpressionFunctions;
 import walkingkooka.tree.expression.function.HasExpressionFunction;
+import walkingkooka.tree.expression.function.InvalidExpressionFunctionParameterCountException;
 
 import java.util.List;
 import java.util.Locale;
@@ -147,6 +148,13 @@ public interface ExpressionEvaluationContext extends ExpressionNumberConverterCo
             result = function.apply(
                 this.prepareParameters(function, parameters),
                 Cast.to(this)
+            );
+        } catch (final InvalidExpressionFunctionParameterCountException cause) {
+            // Function may be wrapped - want to use the outer ExpressionFunction.name
+            result = this.handleException(
+                cause.setFunctionName(
+                    function.name()
+                )
             );
         } catch (final UnsupportedOperationException rethrow) {
             throw rethrow;


### PR DESCRIPTION
…nParameterCountException correct function name

- catch InvalidExpressionFunctionParameterCountException and set ExpressionFunction before handleException