### PR TITLE
BasicExpressionEvaluationContext: ConverterException includes functio…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.expression;
 
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.ConverterContextDelegator;
+import walkingkooka.convert.ConverterException;
 import walkingkooka.locale.LocaleContext;
 import walkingkooka.locale.LocaleContextDelegator;
 import walkingkooka.text.CaseSensitivity;
@@ -149,7 +150,15 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     @Override
     public <T> T prepareParameter(final ExpressionFunctionParameter<T> parameter,
                                   final Object value) {
-        return parameter.convertOrFail(value, this);
+        try {
+            return parameter.convertOrFail(value, this);
+        } catch (final ConverterException rethrow) {
+            throw rethrow.setPrefix(
+                parameter.name()
+                    .value() +
+                    ": "
+            );
+        }
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.expression;
 import walkingkooka.Cast;
 import walkingkooka.Context;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.convert.ConverterException;
 import walkingkooka.locale.LocaleContext;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContext;
@@ -148,6 +149,15 @@ public interface ExpressionEvaluationContext extends ExpressionNumberConverterCo
             result = function.apply(
                 this.prepareParameters(function, parameters),
                 Cast.to(this)
+            );
+        } catch (final ConverterException rethrow) {
+            // HelloFunction: Parameter number: Conversion etc etc.
+            throw rethrow.setPrefix(
+                function.name()
+                    .map(ExpressionFunctionName::value)
+                    .orElse(ExpressionFunction.ANONYMOUS) +
+                    ": " +
+                    rethrow.prefix()
             );
         } catch (final InvalidExpressionFunctionParameterCountException cause) {
             // Function may be wrapped - want to use the outer ExpressionFunction.name


### PR DESCRIPTION
…n and parameter name

- Closes https://github.com/mP1/walkingkooka-tree/issues/981
- BasicExpressionEvaluationContext#prepareParameter message should include parameter name