### PR TITLE
ExpressionFunctionParameterCast ConverterException special case

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCast.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,23 +37,21 @@ class ExpressionFunctionParameterCast extends ExpressionFunctionParameterCastGwt
                     .orElse(null);
             }
 
+            // dont prefix with Parameter when a ConverterException message.
             if (null == invalidTypeMessage) {
-                invalidTypeMessage = "Invalid type " +
+                invalidTypeMessage = "Parameter " +
+                    CharSequences.quoteAndEscape(
+                        parameter.name()
+                            .value()
+                    ) +
+                    ": Invalid type " +
                     value.getClass().getName() +
                     " expected " +
                     type.getName();
             }
 
             // Invalid parameter "name" value "Actual" expected "Expected".
-            throw new ClassCastException(
-                "Parameter " +
-                    CharSequences.quoteAndEscape(
-                        parameter.name()
-                            .value()
-                    ) +
-                    ": " +
-                    invalidTypeMessage
-            );
+            throw new ClassCastException(invalidTypeMessage);
         }
         return type.cast(value);
     }

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCastTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCastTest.java
@@ -46,15 +46,15 @@ public final class ExpressionFunctionParameterCastTest implements ClassTesting2<
 
     @Test
     public void testCastWithHasConvertErrorFails() {
+        final String message = "Cannot convert 'Hello' to 'Void' blah blah blah";
+
         final ClassCastException thrown = assertThrows(
             ClassCastException.class,
             () -> ExpressionFunctionParameterCast.cast(
                 new HasConvertError() {
                     @Override
                     public Optional<String> convertErrorMessage() {
-                        return Optional.of(
-                            "Cannot convert 'Hello' to 'Void' blah blah blah"
-                        );
+                        return Optional.of(message);
                     }
                 },
                 this.parameter(Void.class)
@@ -62,7 +62,7 @@ public final class ExpressionFunctionParameterCastTest implements ClassTesting2<
         );
 
         this.checkEquals(
-            "Parameter \"Parameter\": Cannot convert 'Hello' to 'Void' blah blah blah",
+            message,
             thrown.getMessage()
         );
     }


### PR DESCRIPTION
- Removes redundant "Parameter X" when value is a SpreadsheetError which should have function and parameter name in message.