### PR TITLE
ExpressionEvaluationContext extends EnvironmentContext

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionNodeName.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionNodeName.java
@@ -55,7 +55,7 @@ final class ExpressionFunctionNodeName<C extends ExpressionEvaluationContext> im
                         final C context) {
         this.checkParameterCount(parameters);
 
-        return NODE.getOrFail(parameters, 0)
+        return NODE.getOrFail(parameters, 0, context)
             .name()
             .value();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterDefaultValue.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterDefaultValue.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression.function;
+
+import walkingkooka.ToStringBuilder;
+import walkingkooka.UsesToStringBuilder;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A {@link Function} that holds a fixed value for a {@link ExpressionFunctionParameter#defaultValue()}
+ */
+final class ExpressionFunctionParameterDefaultValue<T> implements Function<ExpressionEvaluationContext, Optional<T>>,
+    UsesToStringBuilder {
+
+    static <T> ExpressionFunctionParameterDefaultValue<T> with(final Optional<T> value) {
+        return new ExpressionFunctionParameterDefaultValue<>(
+            Objects.requireNonNull(value, "value")
+        );
+    }
+
+    private ExpressionFunctionParameterDefaultValue(final Optional<T> value) {
+        this.value = value;
+    }
+
+    @Override
+    public Optional<T> apply(final ExpressionEvaluationContext context) {
+        Objects.requireNonNull(context, "context");
+        return this.value;
+    }
+
+    private final Optional<T> value;
+
+    @Override
+    public String toString() {
+        return String.valueOf(
+            value.orElse(null)
+        );
+    }
+
+    @Override
+    public void buildToString(final ToStringBuilder b) {
+        b.value(this.value);
+    }
+}

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterName.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterName.java
@@ -25,7 +25,6 @@ import walkingkooka.text.CaseSensitivity;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.TreeMap;
 
 /**
@@ -143,7 +142,7 @@ public final class ExpressionFunctionParameterName implements Name,
             this,
             type,
             cardinality,
-            Optional.empty(),
+            ExpressionFunctionParameter.withoutDefaultValue(),
             ExpressionFunctionParameter.NO_KINDS
         );
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTypeName.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctionTypeName.java
@@ -63,7 +63,7 @@ final class ExpressionFunctionTypeName<C extends ExpressionEvaluationContext> im
                         final C context) {
         this.checkParameterCount(parameters);
 
-        return PARAMETER.getOrFail(parameters, 0)
+        return PARAMETER.getOrFail(parameters, 0, context)
             .getClass()
             .getName();
     }

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNumberFunctionExpressionFunction.java
@@ -61,7 +61,7 @@ final class ExpressionNumberFunctionExpressionFunction<C extends ExpressionEvalu
                                   final C context) {
         this.checkParameterCount(parameters);
 
-        return NUMBER.getOrFail(parameters, 0)
+        return NUMBER.getOrFail(parameters, 0, context)
             .map(
                 this.function,
                 context.mathContext()

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -412,7 +412,11 @@ public final class BasicExpressionEvaluationContextTest implements ClassTesting2
                     @Override
                     public Object apply(final List<Object> values,
                                         final ExpressionEvaluationContext context) {
-                        ExpressionFunctionParameter.NUMBER.getOrFail(values, 0);
+                        ExpressionFunctionParameter.NUMBER.getOrFail(
+                            values,
+                            0,
+                            context
+                        );
                         throw new UnsupportedOperationException();
                     }
                 },

--- a/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CallExpressionTest.java
@@ -415,7 +415,7 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
 
                             checkEquals(
                                 namedFunctionParameterValue,
-                                a.getOrFail(parameters, 0),
+                                a.getOrFail(parameters, 0, context),
                                 "a"
                             );
                             return new FakeExpressionFunction<>() {
@@ -441,8 +441,16 @@ public final class CallExpressionTest extends VariableExpressionTestCase<CallExp
                                                     final ExpressionEvaluationContext context) {
                                     this.checkParameterCount(parameters);
 
-                                    final ExpressionNumber x = this.x.getOrFail(parameters, 0);
-                                    final ExpressionNumber y = this.y.getOrFail(parameters, 1);
+                                    final ExpressionNumber x = this.x.getOrFail(
+                                        parameters,
+                                        0,
+                                        context
+                                    );
+                                    final ExpressionNumber y = this.y.getOrFail(
+                                        parameters,
+                                        1,
+                                        context
+                                    );
                                     return x.add(y, context);
                                 }
 

--- a/src/test/java/walkingkooka/tree/expression/ScopedExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ScopedExpressionEvaluationContextTest.java
@@ -263,7 +263,7 @@ public final class ScopedExpressionEvaluationContextTest implements ExpressionEv
                     ExpressionFunctionParameterName.with("reference-parameter"),
                     Object.class,
                     ExpressionFunctionParameterCardinality.REQUIRED,
-                    Optional.empty(), // defaultValue
+                    ExpressionFunctionParameter.withoutDefaultValue(), // defaultValue
                     ExpressionFunctionParameter.NO_KINDS
                 )
             );

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCastTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterCastTest.java
@@ -102,7 +102,7 @@ public final class ExpressionFunctionParameterCastTest implements ClassTesting2<
             ExpressionFunctionParameterName.with("Parameter"),
             parameterType,
             ExpressionFunctionParameterCardinality.REQUIRED,
-            Optional.empty(), // no defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(), // no defaultValue
             ExpressionFunctionParameter.NO_KINDS
         );
     }

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterDefaultValueTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterDefaultValueTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.expression.function;
+
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.util.FunctionTesting;
+
+import java.util.Optional;
+
+public final class ExpressionFunctionParameterDefaultValueTest implements FunctionTesting<ExpressionFunctionParameterDefaultValue<Integer>, ExpressionEvaluationContext, Optional<Integer>> {
+
+    @Override
+    public ExpressionFunctionParameterDefaultValue<Integer> createFunction() {
+        return ExpressionFunctionParameterDefaultValue.with(
+            Optional.of(123)
+        );
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public void testTypeNaming() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Class<ExpressionFunctionParameterDefaultValue<Integer>> type() {
+        return Cast.to(ExpressionFunctionParameterDefaultValue.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionFunctionParameterTest.java
@@ -29,6 +29,7 @@ import walkingkooka.reflect.ConstantsTesting;
 import walkingkooka.reflect.FieldAttributes;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionEvaluationContexts;
 import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
 import java.lang.reflect.Field;
@@ -37,6 +38,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -52,9 +54,11 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
 
     private final static ExpressionFunctionParameterCardinality CARDINALITY = ExpressionFunctionParameterCardinality.REQUIRED;
 
-    private final static Optional<String> DEFAULT_VALUE = Optional.of("DefaultStringValue");
+    private final static Function<ExpressionEvaluationContext, Optional<String>> DEFAULT_VALUE = (final ExpressionEvaluationContext e) -> Optional.of("DefaultStringValue");
 
     private final static Set<ExpressionFunctionParameterKind> KINDS = ExpressionFunctionParameter.NO_KINDS;
+
+    private final static ExpressionEvaluationContext CONTEXT = ExpressionEvaluationContexts.fake();
 
     @Test
     public void testWithNullNameFails() {
@@ -269,7 +273,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Cast.to(List.class),
             CARDINALITY,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             kinds
         );
         assertSame(
@@ -286,7 +290,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Cast.to(type),
             CARDINALITY,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
 
@@ -359,22 +363,6 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
         );
     }
 
-    private void defaultValueAndCheck(final ExpressionFunctionParameter<?> parameter) {
-        this.defaultValueAndCheck(
-            parameter,
-            DEFAULT_VALUE
-        );
-    }
-
-    private void defaultValueAndCheck(final ExpressionFunctionParameter<?> parameter,
-                                      final Optional<?> defaultValue) {
-        this.checkEquals(
-            parameter.defaultValue(),
-            defaultValue,
-            "defaultValue"
-        );
-    }
-
     private void kindsAndCheck(final ExpressionFunctionParameter<?> parameter) {
         this.kindsAndCheck(
             parameter,
@@ -399,14 +387,15 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
             NullPointerException.class,
             () -> parameter.get(
                 null,
-                0
+                0,
+                CONTEXT
             )
         );
     }
@@ -418,7 +407,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
@@ -427,7 +416,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 List.of(
                     "A"
                 ),
-                0
+                0,
+                CONTEXT
             )
         );
     }
@@ -438,7 +428,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.of(999), // defaultValue
+            (c) -> Optional.of(999), // defaultValue
             KINDS
         );
         this.checkEquals(
@@ -447,7 +437,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 List.of(
                     100
                 ),
-                1
+                1,
+                CONTEXT
             )
         );
     }
@@ -458,7 +449,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getAndCheck(
@@ -476,7 +467,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getAndCheck(
@@ -496,7 +487,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getAndCheck(
@@ -515,7 +506,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getAndCheck(
@@ -534,7 +525,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.of(999), // defaultValue
+            (c) -> Optional.of(999), // defaultValue
             KINDS
         );
         this.getAndCheck(
@@ -579,7 +570,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             expected,
             parameter.get(
                 values,
-                index
+                index,
+                CONTEXT
             ),
             () -> parameter + " get " + index
         );
@@ -593,14 +585,15 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.REQUIRED,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
             NullPointerException.class,
             () -> parameter.getOrFail(
                 null,
-                0
+                0,
+                CONTEXT
             )
         );
     }
@@ -611,7 +604,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.REQUIRED,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
@@ -620,7 +613,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 List.of(
                     1, 2
                 ),
-                2
+                2,
+                CONTEXT
             )
         );
     }
@@ -632,7 +626,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.REQUIRED,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
@@ -641,7 +635,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 List.of(
                     "A"
                 ),
-                0
+                0,
+                CONTEXT
             )
         );
     }
@@ -652,7 +647,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.REQUIRED,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getOrFailAndCheck(
@@ -672,7 +667,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.getOrFailAndCheck(
@@ -692,7 +687,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.OPTIONAL,
-            Optional.of(999), // defaultValue
+            (c) -> Optional.of(999), // defaultValue
             KINDS
         );
         this.getOrFailAndCheck(
@@ -714,7 +709,8 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             expected,
             parameter.getOrFail(
                 values,
-                index
+                index,
+                CONTEXT
             ),
             () -> parameter + " get " + index
         );
@@ -728,14 +724,15 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.VARIABLE,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         assertThrows(
             NullPointerException.class,
             () -> parameter.getOrFail(
                 null,
-                0
+                0,
+                CONTEXT
             )
         );
     }
@@ -746,7 +743,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.VARIABLE,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.checkEquals(
@@ -766,7 +763,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.VARIABLE,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.checkEquals(
@@ -789,7 +786,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             ExpressionFunctionParameterCardinality.VARIABLE,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
         this.checkEquals(
@@ -816,7 +813,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
             NAME,
             Integer.class,
             CARDINALITY,
-            Optional.empty(), // defaultValue
+            ExpressionFunctionParameter.withoutDefaultValue(),
             KINDS
         );
 
@@ -906,7 +903,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 Integer.class,
                 CARDINALITY,
-                Optional.empty(),
+                ExpressionFunctionParameter.withoutDefaultValue(),
                 KINDS
             )
         );
@@ -947,7 +944,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 TYPE,
                 ExpressionFunctionParameterCardinality.OPTIONAL,
-                Optional.empty(),
+                ExpressionFunctionParameter.withoutDefaultValue(),
                 KINDS
             ),
             "java.lang.String name?"
@@ -961,7 +958,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 TYPE,
                 ExpressionFunctionParameterCardinality.OPTIONAL,
-                Optional.empty(), // defaultValue
+                ExpressionFunctionParameter.withoutDefaultValue(),
                 KINDS
             ),
             "java.lang.String name?"
@@ -975,7 +972,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 TYPE,
                 ExpressionFunctionParameterCardinality.REQUIRED,
-                Optional.empty(), // defaultValue
+                ExpressionFunctionParameter.withoutDefaultValue(),
                 KINDS
             ),
             "java.lang.String name"
@@ -989,7 +986,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 TYPE,
                 ExpressionFunctionParameterCardinality.VARIABLE,
-                Optional.empty(), // defaultValue
+                ExpressionFunctionParameter.withoutDefaultValue(),
                 KINDS
             ),
             "java.lang.String name*"
@@ -1003,7 +1000,7 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 List.class,
                 ExpressionFunctionParameterCardinality.REQUIRED,
-                Optional.empty(), // defaultValue
+                ExpressionFunctionParameter.withoutDefaultValue(), // defaultValue
                 EnumSet.of(
                     ExpressionFunctionParameterKind.CONVERT,
                     ExpressionFunctionParameterKind.EVALUATE
@@ -1020,9 +1017,11 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 List.class,
                 ExpressionFunctionParameterCardinality.REQUIRED,
-                Optional.of(
-                    Lists.of("DefaultValue")
-                ), // defaultValue
+                ExpressionFunctionParameter.defaultValue(
+                    Optional.of(
+                        Lists.of("DefaultValue")
+                    )
+                ),
                 EnumSet.of(
                     ExpressionFunctionParameterKind.CONVERT,
                     ExpressionFunctionParameterKind.EVALUATE
@@ -1039,7 +1038,9 @@ public final class ExpressionFunctionParameterTest implements HashCodeEqualsDefi
                 NAME,
                 Integer.class,
                 ExpressionFunctionParameterCardinality.REQUIRED,
-                Optional.of(123), // defaultValue
+                ExpressionFunctionParameter.defaultValue(
+                    Optional.of(123)
+                ),
                 EnumSet.of(
                     ExpressionFunctionParameterKind.CONVERT,
                     ExpressionFunctionParameterKind.EVALUATE

--- a/src/test/java/walkingkooka/tree/sample/Sample.java
+++ b/src/test/java/walkingkooka/tree/sample/Sample.java
@@ -24,6 +24,7 @@ import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
 import walkingkooka.tree.expression.function.ExpressionFunctionParameterName;
@@ -74,7 +75,8 @@ public final class Sample {
                     100,
                     "B"
                 ),
-                0
+                0,
+                ExpressionEvaluationContexts.fake()
             )
         );
     }


### PR DESCRIPTION
- Supports using an EnvironmentValueName to fetch an environment value as a default for a parameter.

- Closes https://github.com/mP1/walkingkooka-tree/issues/996
- ExpressionFunctionParameter.setDefaultValue: Function<ExpressionEvaluationContext, Optional<T>> replaces Optional<T>