### PR TITLE
NodeSelectorParsersGrammar interface was class (mvn annotation proces…

### DIFF
--- a/src/main/java/walkingkooka/tree/select/parser/NodeSelectorParsersGrammar.java
+++ b/src/main/java/walkingkooka/tree/select/parser/NodeSelectorParsersGrammar.java
@@ -20,5 +20,5 @@ package walkingkooka.tree.select.parser;
 import walkingkooka.resource.TextResourceAware;
 
 @TextResourceAware(normalizeSpace = true)
-class NodeSelectorParsersGrammar {
+interface NodeSelectorParsersGrammar {
 }


### PR DESCRIPTION
…sor) FIX

- This change seems to ensure annotations processors are "run" and generate classes when mvn is run from the command line.